### PR TITLE
fix: create .idea directory if missing

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
@@ -179,7 +179,10 @@ class CopilotPluginUtil {
                     VfsUtil.findFileByIoFile(ideaDir, false)?.let {
                         return@runReadAction PsiManager.getInstance(project).findDirectory(it)
                     }
-                    LOG.warn("$ideaDir is not available")
+                    VfsUtil.createDirectoryIfMissing(ideaDir.path)?.let {
+                        LOG.info("$ideaDir created")
+                        return@runReadAction PsiManager.getInstance(project).findDirectory(it)
+                    }
                 }
                 return@runReadAction null
             }


### PR DESCRIPTION
## Description

Creates .idea directory if not yet initialized by IntelliJ itself.

Can be tested using:
[intellij-plugin-1.0-SNAPSHOT.zip](https://github.com/vaadin/intellij-plugin/files/14664756/intellij-plugin-1.0-SNAPSHOT.zip)


Fixes #13 
