### PR TITLE
chore: open editor after file has been saved

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteFileHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteFileHandler.kt
@@ -5,6 +5,8 @@ import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.command.UndoConfirmationPolicy
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.actionSystem.DocCommandGroupId
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.ReadonlyStatusHandler
@@ -51,6 +53,9 @@ class WriteFileHandler(project: Project, data: Map<String, Any>) : AbstractHandl
                         it.setText(content)
                         commitAndFlush(it)
                         LOG.info("File $ioFile contents saved")
+
+                        val openFileDescriptor = OpenFileDescriptor(project, vfsFile)
+                        FileEditorManager.getInstance(project).openTextEditor(openFileDescriptor, false)
 
                         ProjectTaskManager.getInstance(project).compile(vfsFile).then {
                             LOG.info("File $ioFile compiled")


### PR DESCRIPTION
## Description

Open editor when saving file contents

Fixes https://github.com/vaadin/copilot-internal/issues/1817