### PR TITLE
fix: open in editor and compile new created files

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/RefreshHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/RefreshHandler.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.vfs.VirtualFileManager
 class RefreshHandler(project: Project) : AbstractHandler(project) {
 
     override fun run() {
-        VirtualFileManager.getInstance().asyncRefresh {  }
+        VirtualFileManager.getInstance().syncRefresh()
     }
 
 }

--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteFileHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteFileHandler.kt
@@ -93,7 +93,7 @@ class WriteFileHandler(project: Project, data: Map<String, Any>) : AbstractHandl
                         LOG.info("File $ioFile contents saved")
                     },
                     undoLabel ?: "Vaadin Copilot Write File",
-                    DocCommandGroupId.noneGroupId(null),
+                    null,
                     UndoConfirmationPolicy.DO_NOT_REQUEST_CONFIRMATION
                 )
             }

--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteFileHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteFileHandler.kt
@@ -9,10 +9,7 @@ import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.Strings
-import com.intellij.openapi.vfs.ReadonlyStatusHandler
-import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.findDocument
+import com.intellij.openapi.vfs.*
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiManager
 import com.intellij.task.ProjectTaskManager
@@ -75,6 +72,7 @@ class WriteFileHandler(project: Project, data: Map<String, Any>) : AbstractHandl
     private fun compile(vfsFile: VirtualFile) {
         ProjectTaskManager.getInstance(project).compile(vfsFile).then {
             LOG.info("File $ioFile compiled")
+            VirtualFileManager.getInstance().syncRefresh()
         }
     }
 


### PR DESCRIPTION
## Description

In this PR:

Open in editor and compile newly created files.

Compiled resources files are placed in target/.

Minor remark: ide file tree might not be refreshed when "Add file to git" is confirmed. Reload from Disk manually to check if file has been created.
