### PR TITLE
chore: lower supported version to 2022.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
 
 tasks {
     patchPluginXml {
-        sinceBuild.set("233")
+        sinceBuild.set("223")
         untilBuild.set("242.*")
     }
 


### PR DESCRIPTION
As in title,  to be in line with https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html#requirements