### PR TITLE
chore: use compatible versions

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -22,7 +22,7 @@ jobs:
           cache: gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-      - name: Build with Gradle
+      - name: Build plugin
         run: ./gradlew --no-configuration-cache buildPlugin
       - uses: actions/upload-artifact@v4.3.3
         id: artifact
@@ -48,5 +48,5 @@ jobs:
           cache: gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-      - name: Build with Gradle
+      - name: Verify plugin
         run: ./gradlew --no-configuration-cache verifyPlugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,13 @@
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.9.21"
     id("org.jetbrains.intellij.platform") version "2.0.0"
 }
+
+val compatibilitySince = "233"
+val compatibilityUntil = "242.*"
 
 group = "com.vaadin"
 val publishChannel = if (hasProperty("publishChannel")) {
@@ -21,7 +26,11 @@ intellijPlatform {
     }
     pluginVerification {
         ides {
-            recommended()
+            select {
+                types = listOf(IntelliJPlatformType.IntellijIdeaCommunity)
+                sinceBuild = compatibilitySince
+                untilBuild = compatibilityUntil
+            }
         }
     }
 }
@@ -55,8 +64,8 @@ dependencies {
 
 tasks {
     patchPluginXml {
-        sinceBuild.set("223")
-        untilBuild.set("242.*")
+        sinceBuild.set(compatibilitySince)
+        untilBuild.set(compatibilityUntil)
     }
 
     signPlugin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,6 @@ plugins {
     id("org.jetbrains.intellij.platform") version "2.0.0"
 }
 
-val compatibilitySince = "233"
-val compatibilityUntil = "242.*"
-
 group = "com.vaadin"
 val publishChannel = if (hasProperty("publishChannel")) {
     property("publishChannel") as String
@@ -58,8 +55,8 @@ dependencies {
 
 tasks {
     patchPluginXml {
-        sinceBuild.set(compatibilitySince)
-        untilBuild.set(compatibilityUntil)
+        sinceBuild.set("233")
+        untilBuild.set("242.*")
     }
 
     signPlugin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
-
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.9.21"
@@ -26,9 +24,7 @@ intellijPlatform {
     }
     pluginVerification {
         ides {
-            ide(IntelliJPlatformType.IntellijIdeaCommunity, compatibilitySince)
             recommended()
-            ide(IntelliJPlatformType.IntellijIdeaCommunity, compatibilityUntil)
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,11 +26,9 @@ intellijPlatform {
     }
     pluginVerification {
         ides {
-            select {
-                types = listOf(IntelliJPlatformType.IntellijIdeaCommunity)
-                sinceBuild = compatibilitySince
-                untilBuild = compatibilityUntil
-            }
+            ide(IntelliJPlatformType.IntellijIdeaCommunity, compatibilitySince)
+            recommended()
+            ide(IntelliJPlatformType.IntellijIdeaCommunity, compatibilityUntil)
         }
     }
 }


### PR DESCRIPTION
Due to incompatibility of SegmentButton API in versions 223 and 233 I needed to rollback previous version lowering.