### PR TITLE
feat: Compile on save

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
@@ -1,0 +1,52 @@
+package com.vaadin.plugin.actions
+
+import com.intellij.ide.actionsOnSave.impl.ActionsOnSaveFileDocumentManagerListener
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.task.ProjectTaskManager
+import com.vaadin.plugin.actions.VaadinCompileOnSaveActionInfo.Companion.DEFAULT
+import com.vaadin.plugin.actions.VaadinCompileOnSaveActionInfo.Companion.PROPERTY
+import com.vaadin.plugin.copilot.CopilotPluginUtil
+
+class VaadinCompileOnSaveAction : ActionsOnSaveFileDocumentManagerListener.ActionOnSave() {
+
+    private val LOG: Logger = Logger.getInstance(CopilotPluginUtil::class.java)
+
+    override fun isEnabledForProject(project: Project): Boolean {
+        return PropertiesComponent.getInstance(project).getBoolean(PROPERTY, DEFAULT)
+    }
+
+    override fun processDocuments(project: Project, documents: Array<Document?>) {
+        if (documents.size != 1) {
+            return
+        }
+
+        val doc = documents[0] ?: return
+        val vfsFile = FileDocumentManager.getInstance().getFile(doc) ?: return
+        compile(project, vfsFile)
+    }
+
+    fun compile(project: Project, vfsFile: VirtualFile) {
+        if (!vfsFile.extension.equals("java")) {
+            return
+        }
+
+        val task = object : Task.Backgroundable(project, "Vaadin: compiling...") {
+            override fun run(indicator: ProgressIndicator) {
+                ProjectTaskManager.getInstance(project).compile(vfsFile).then {
+                    LOG.info("File $vfsFile compiled")
+                    VirtualFileManager.getInstance().syncRefresh()
+                }
+            }
+        }
+        ProgressManager.getInstance().run(task)
+    }
+}

--- a/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
@@ -1,5 +1,7 @@
 package com.vaadin.plugin.actions
 
+import com.intellij.debugger.DebuggerManagerEx
+import com.intellij.debugger.ui.HotSwapUI
 import com.intellij.ide.actionsOnSave.impl.ActionsOnSaveFileDocumentManagerListener
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.diagnostic.Logger
@@ -10,8 +12,6 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.task.ProjectTaskManager
 import com.vaadin.plugin.actions.VaadinCompileOnSaveActionInfo.Companion.DEFAULT
 import com.vaadin.plugin.actions.VaadinCompileOnSaveActionInfo.Companion.PROPERTY
 import com.vaadin.plugin.copilot.CopilotPluginUtil
@@ -41,9 +41,10 @@ class VaadinCompileOnSaveAction : ActionsOnSaveFileDocumentManagerListener.Actio
 
         val task = object : Task.Backgroundable(project, "Vaadin: compiling...") {
             override fun run(indicator: ProgressIndicator) {
-                ProjectTaskManager.getInstance(project).compile(vfsFile).then {
+                val session = DebuggerManagerEx.getInstanceEx(project).context.debuggerSession
+                if (session != null) {
+                    HotSwapUI.getInstance(project).compileAndReload(session, vfsFile)
                     LOG.info("File $vfsFile compiled")
-                    VirtualFileManager.getInstance().syncRefresh()
                 }
             }
         }

--- a/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveActionInfo.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveActionInfo.kt
@@ -1,0 +1,20 @@
+package com.vaadin.plugin.actions
+
+import com.intellij.codeInsight.actions.onSave.ActionOnSaveInfoBase
+import com.intellij.ide.actionsOnSave.ActionOnSaveComment
+import com.intellij.ide.actionsOnSave.ActionOnSaveContext
+
+class VaadinCompileOnSaveActionInfo(context: ActionOnSaveContext) :
+    ActionOnSaveInfoBase(context, NAME, PROPERTY, DEFAULT) {
+
+    companion object {
+        const val NAME = "Vaadin - compile on save"
+        const val PROPERTY = "vaadin.compileOnSave"
+        const val DEFAULT = true
+        const val DESCRIPTION = "Compiles Java files on save to improve Flow applications development experience"
+    }
+
+    override fun getComment(): ActionOnSaveComment? {
+        return ActionOnSaveComment.info(DESCRIPTION)
+    }
+}

--- a/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveActionInfo.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveActionInfo.kt
@@ -11,7 +11,7 @@ class VaadinCompileOnSaveActionInfo(context: ActionOnSaveContext) :
         const val NAME = "Compile on save"
         const val PROPERTY = "vaadin.compileOnSave"
         const val DEFAULT = true
-        const val DESCRIPTION = "Compiles *.java"
+        const val DESCRIPTION = "Compiles *.java while debugging"
     }
 
     override fun getComment(): ActionOnSaveComment? {

--- a/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveActionInfo.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveActionInfo.kt
@@ -8,10 +8,10 @@ class VaadinCompileOnSaveActionInfo(context: ActionOnSaveContext) :
     ActionOnSaveInfoBase(context, NAME, PROPERTY, DEFAULT) {
 
     companion object {
-        const val NAME = "Vaadin - compile on save"
+        const val NAME = "Compile on save"
         const val PROPERTY = "vaadin.compileOnSave"
         const val DEFAULT = true
-        const val DESCRIPTION = "Compiles Java files on save to improve Flow applications development experience"
+        const val DESCRIPTION = "Compiles *.java"
     }
 
     override fun getComment(): ActionOnSaveComment? {

--- a/src/main/kotlin/com/vaadin/plugin/actions/VaadinOnSaveInfoProvider.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/VaadinOnSaveInfoProvider.kt
@@ -1,0 +1,15 @@
+package com.vaadin.plugin.actions
+
+import com.intellij.ide.actionsOnSave.ActionOnSaveContext
+import com.intellij.ide.actionsOnSave.ActionOnSaveInfo
+import com.intellij.ide.actionsOnSave.ActionOnSaveInfoProvider
+
+class VaadinOnSaveInfoProvider : ActionOnSaveInfoProvider() {
+
+    override fun getActionOnSaveInfos(p0: ActionOnSaveContext): MutableCollection<out ActionOnSaveInfo> {
+        val info: ArrayList<ActionOnSaveInfo> = ArrayList()
+        info.add(VaadinCompileOnSaveActionInfo(p0))
+        return info
+    }
+
+}

--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/RedoHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/RedoHandler.kt
@@ -1,8 +1,11 @@
 package com.vaadin.plugin.copilot.handler
 
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.command.impl.UndoManagerImpl
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.findDocument
+import com.vaadin.plugin.actions.VaadinCompileOnSaveAction
 
 class RedoHandler(project: Project, data: Map<String, Any>) : UndoHandler(project, data) {
 
@@ -10,16 +13,20 @@ class RedoHandler(project: Project, data: Map<String, Any>) : UndoHandler(projec
 
     override fun run() {
         for (vfsFile in vfsFiles) {
-            getEditorWrapper(vfsFile).use { wrapper ->
-                val editor = wrapper.getFileEditor()
-                val undoManager = UndoManagerImpl.getInstance(project)
-                if (undoManager.isRedoAvailable(editor)) {
-                    val redo = undoManager.getRedoActionNameAndDescription(editor).first
-                    if (redo.startsWith(copilotActionPrefix)) {
-                        undoManager.redo(editor)
-                        commitAndFlush(vfsFile.findDocument())
-                        LOG.info("$redo performed on ${vfsFile.path}")
-                        return
+            runInEdt {
+                getEditorWrapper(vfsFile).use { wrapper ->
+                    val editor = wrapper.getFileEditor()
+                    val undoManager = UndoManagerImpl.getInstance(project)
+                    runWriteAction {
+                        if (undoManager.isRedoAvailable(editor)) {
+                            val redo = undoManager.getRedoActionNameAndDescription(editor).first
+                            if (redo.startsWith(copilotActionPrefix)) {
+                                undoManager.redo(editor)
+                                commitAndFlush(vfsFile.findDocument())
+                                LOG.info("$redo performed on ${vfsFile.path}")
+                                VaadinCompileOnSaveAction().compile(project, vfsFile)
+                            }
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/ShowInIdeHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/ShowInIdeHandler.kt
@@ -1,6 +1,7 @@
 package com.vaadin.plugin.copilot.handler
 
 import com.intellij.ide.impl.ProjectUtil
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.ScrollType
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -20,12 +21,14 @@ class ShowInIdeHandler(project: Project, data: Map<String, Any>) : AbstractHandl
         if (isFileInsideProject(project, ioFile)) {
             val result = VfsUtil.findFileByIoFile(ioFile, true)?.let { file ->
                 val openFileDescriptor = OpenFileDescriptor(project, file)
-                FileEditorManager.getInstance(project).openTextEditor(openFileDescriptor, true)?.let { editor ->
-                    editor.selectionModel.removeSelection()
-                    editor.caretModel.currentCaret.moveToLogicalPosition(LogicalPosition(line, column))
-                    editor.scrollingModel.scrollToCaret(ScrollType.CENTER)
+                runInEdt {
+                    FileEditorManager.getInstance(project).openTextEditor(openFileDescriptor, true)?.let { editor ->
+                        editor.selectionModel.removeSelection()
+                        editor.caretModel.currentCaret.moveToLogicalPosition(LogicalPosition(line, column))
+                        editor.scrollingModel.scrollToCaret(ScrollType.CENTER)
+                    }
+                    ProjectUtil.focusProjectWindow(project, true)
                 }
-                ProjectUtil.focusProjectWindow(project, true)
                 LOG.info("File $ioFile opened at $line:$column")
                 true
             }

--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/UndoHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/UndoHandler.kt
@@ -1,10 +1,13 @@
 package com.vaadin.plugin.copilot.handler
 
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.command.impl.UndoManagerImpl
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.findDocument
+import com.vaadin.plugin.actions.VaadinCompileOnSaveAction
 import java.io.File
 
 open class UndoHandler(project: Project, data: Map<String, Any>) : AbstractHandler(project) {
@@ -29,16 +32,20 @@ open class UndoHandler(project: Project, data: Map<String, Any>) : AbstractHandl
 
     override fun run() {
         for (vfsFile in vfsFiles) {
-            getEditorWrapper(vfsFile).use { wrapper ->
-                val undoManager = UndoManagerImpl.getInstance(project)
-                val editor = wrapper.getFileEditor()
-                if (undoManager.isUndoAvailable(editor)) {
-                    val undo = undoManager.getUndoActionNameAndDescription(editor).first
-                    if (undo.startsWith(copilotActionPrefix)) {
-                        undoManager.undo(editor)
-                        commitAndFlush(vfsFile.findDocument())
-                        LOG.info("$undo performed on ${vfsFile.path}")
-                        return
+            runInEdt {
+                getEditorWrapper(vfsFile).use { wrapper ->
+                    val undoManager = UndoManagerImpl.getInstance(project)
+                    val editor = wrapper.getFileEditor()
+                    runWriteAction {
+                        if (undoManager.isUndoAvailable(editor)) {
+                            val undo = undoManager.getUndoActionNameAndDescription(editor).first
+                            if (undo.startsWith(copilotActionPrefix)) {
+                                undoManager.undo(editor)
+                                commitAndFlush(vfsFile.findDocument())
+                                LOG.info("$undo performed on ${vfsFile.path}")
+                                VaadinCompileOnSaveAction().compile(project, vfsFile)
+                            }
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/com/vaadin/plugin/copilot/service/CopilotRestService.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/service/CopilotRestService.kt
@@ -2,7 +2,6 @@ package com.vaadin.plugin.copilot.service
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.ProjectManager
 import com.vaadin.plugin.copilot.CommandRequest
@@ -47,9 +46,7 @@ class CopilotRestService : RestService() {
             return null
         }
 
-        runInEdt {
-            CopilotPluginUtil.createCommandHandler(copilotRequest.command, project, copilotRequest.data)?.run()
-        }
+        CopilotPluginUtil.createCommandHandler(copilotRequest.command, project, copilotRequest.data)?.run()
 
         sendOk(request, context)
         return null

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -24,6 +24,7 @@
     <!-- Product and plugin compatibility requirements.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.modules.java</depends>
 
     <change-notes>
         <![CDATA[

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,6 +44,13 @@
 
         <!-- Vaadin Project Wizard -->
         <moduleBuilder id="VaadinModuleBuilder" builderClass="com.vaadin.plugin.module.VaadinProjectBuilderAdapter"/>
+
+        <actionOnSaveInfoProvider id="VaadinCompileOnSaveInfoProvider"
+                                  implementation="com.vaadin.plugin.actions.VaadinOnSaveInfoProvider"
+                                  order="last"/>
+        <actionOnSave id="VaadinCompileOnSaveAction"
+                      implementation="com.vaadin.plugin.actions.VaadinCompileOnSaveAction" order="last"/>
+
     </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
## Description

In this PR:
- added action on save that monitors user file modifications and performs single file compilation (for `.java` files only)
- removed `runInEdt{ }` for all plugin handlers, now run as small parts as possible in event dispatch thread
- writeFile triggers compile

Fixes https://github.com/vaadin/copilot-internal/issues/2968