### PR TITLE
chore: bring back RunOnce, add action to manually install or update hotswap-agent.jar

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/actions/InstallOrUpdateHotSwapAction.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/InstallOrUpdateHotSwapAction.kt
@@ -1,0 +1,24 @@
+package com.vaadin.plugin.actions
+
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.vaadin.plugin.copilot.CopilotPluginUtil
+import com.vaadin.plugin.utils.VaadinHomeUtil
+
+class InstallOrUpdateHotSwapAction : AnAction() {
+
+    override fun actionPerformed(p0: AnActionEvent) {
+        val version = VaadinHomeUtil.updateOrInstallHotSwapJar()
+        if (version != null) {
+            CopilotPluginUtil.notify("hotswap-agent.jar:$version installed", NotificationType.INFORMATION, p0.project)
+        } else {
+            CopilotPluginUtil.notify(
+                "Installation of hotswap-agent.jar failed, see logs for details",
+                NotificationType.ERROR,
+                p0.project
+            )
+        }
+    }
+
+}

--- a/src/main/kotlin/com/vaadin/plugin/activity/ConfigurationCheckPostStartupProjectActivity.kt
+++ b/src/main/kotlin/com/vaadin/plugin/activity/ConfigurationCheckPostStartupProjectActivity.kt
@@ -3,6 +3,7 @@ package com.vaadin.plugin.activity
 import com.intellij.debugger.JavaDebuggerBundle
 import com.intellij.debugger.settings.DebuggerSettings
 import com.intellij.ide.IdeCoreBundle
+import com.intellij.ide.util.RunOnceUtil
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationType
@@ -15,6 +16,7 @@ import com.intellij.openapi.vcs.VcsBundle
 import com.intellij.openapi.vcs.VcsConfiguration
 import com.intellij.openapi.vcs.VcsShowConfirmationOption
 import com.intellij.openapi.vcs.impl.ProjectLevelVcsManagerImpl
+import com.vaadin.plugin.copilot.CopilotPluginUtil
 import com.vaadin.plugin.utils.VaadinHomeUtil
 import com.vaadin.plugin.utils.VaadinIcons
 
@@ -39,7 +41,9 @@ class ConfigurationCheckPostStartupProjectActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
         checkReloadClassesSetting(project)
         checkVcsAddConfirmationSetting(project)
-        VaadinHomeUtil.updateOrInstallHotSwapJar()
+        RunOnceUtil.runOnceForApp("hotswap-version-check-" + CopilotPluginUtil.getPluginVersion()) {
+            VaadinHomeUtil.updateOrInstallHotSwapJar()
+        }
     }
 
     private fun checkReloadClassesSetting(project: Project) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -66,4 +66,13 @@
         <notificationGroup id="Vaadin Configuration Check" displayType="STICKY_BALLOON"/>
     </extensions>
 
+    <actions>
+        <action
+                id="HotSwap.installOrUpdate"
+                class="com.vaadin.plugin.actions.InstallOrUpdateHotSwapAction"
+                text="HotSwap: Install or update"
+                description="Installs or updates hotswap-agent.jar">
+        </action>
+    </actions>
+
 </idea-plugin>


### PR DESCRIPTION
hotswap-agent.jar is being installed or updated once for given plugin version. In case of missing file user can now just call HotSwap: Install or update action to bring it back.