### PR TITLE
fix: checks if project is Vaadin project based on modules libraries

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
@@ -21,9 +21,7 @@ import io.netty.handler.codec.http.HttpResponseStatus
 import java.io.BufferedWriter
 import java.io.File
 import java.io.StringWriter
-import java.nio.file.Files
 import java.util.*
-import kotlin.io.path.Path
 
 
 class CopilotPluginUtil {
@@ -33,8 +31,6 @@ class CopilotPluginUtil {
         private val LOG: Logger = Logger.getInstance(CopilotPluginUtil::class.java)
 
         private const val DOTFILE = ".copilot-plugin"
-
-        private const val VAADIN_LIB_PREFIX = "com.vaadin"
 
         private const val IDEA_DIR = ".idea"
 
@@ -53,34 +49,8 @@ class CopilotPluginUtil {
 
         private val pluginVersion = PluginManagerCore.getPlugin(PluginId.getId("com.vaadin.intellij-plugin"))?.version
 
-        fun isVaadinProject(project: Project): Boolean {
-            if (project.basePath == null) {
-                return false
-            }
-
-            val containsVaadinDeps = fun(file: String): Boolean {
-                return Files.readString(Path(project.basePath!!, file)).contains(VAADIN_LIB_PREFIX)
-            }
-
-            // Maven projects
-            if (File(project.basePath, "pom.xml").exists()) {
-                return containsVaadinDeps("pom.xml")
-            }
-
-            // Gradle projects
-            if (File(project.basePath, "build.gradle").exists()) {
-                return containsVaadinDeps("build.gradle")
-            }
-
-            // Gradle Kotlin projects
-            if (File(project.basePath, "build.gradle.kts").exists()) {
-                return containsVaadinDeps("build.gradle.kts")
-            }
-
-            return false
-        }
-        fun getPluginVersion(): String?{
-            return pluginVersion;
+        fun getPluginVersion(): String? {
+            return pluginVersion
         }
 
         fun notify(content: String, type: NotificationType, project: Project?) {
@@ -120,7 +90,7 @@ class CopilotPluginUtil {
                 props.setProperty("endpoint", RestUtil.getEndpoint())
                 props.setProperty("ide", "intellij")
                 props.setProperty("version", pluginVersion)
-                props.setProperty("supportedActions", HANDLERS.values().map { a -> a.command }.joinToString(","))
+                props.setProperty("supportedActions", HANDLERS.entries.joinToString(",") { a -> a.command })
 
                 val stringWriter = StringWriter()
                 val bufferedWriter = object : BufferedWriter(stringWriter) {

--- a/src/main/kotlin/com/vaadin/plugin/copilot/activity/CopilotPostStartupProjectActivity.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/activity/CopilotPostStartupProjectActivity.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.project.ProjectManagerListener
 import com.intellij.openapi.startup.ProjectActivity
 import com.vaadin.plugin.copilot.CopilotPluginUtil
+import com.vaadin.plugin.utils.VaadinProjectUtil
 import org.jetbrains.ide.BuiltInServerManager
 
 class CopilotPostStartupProjectActivity : ProjectActivity {
@@ -13,8 +14,7 @@ class CopilotPostStartupProjectActivity : ProjectActivity {
 
         BuiltInServerManager.getInstance().waitForStart()
 
-        val isVaadinProject = CopilotPluginUtil.isVaadinProject(project)
-        if (isVaadinProject) {
+        if (VaadinProjectUtil.isVaadinProject(project)) {
             val dotFileDirectory = CopilotPluginUtil.getDotFileDirectory(project)
             if (dotFileDirectory == null) {
                 CopilotPluginUtil.createIdeaDirectoryIfMissing(project)

--- a/src/main/kotlin/com/vaadin/plugin/utils/VaadinProjectUtil.kt
+++ b/src/main/kotlin/com/vaadin/plugin/utils/VaadinProjectUtil.kt
@@ -1,8 +1,11 @@
 package com.vaadin.plugin.utils
 
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.observable.properties.GraphProperty
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.libraries.Library
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -67,6 +70,19 @@ class VaadinProjectUtil {
                 }
                 return null
             }
+        }
+
+        fun isVaadinProject(project: Project): Boolean {
+            var hasVaadin = false
+            ModuleManager.getInstance(project).modules.forEach { module ->
+                ModuleRootManager.getInstance(module).orderEntries().forEachLibrary { library: Library ->
+                    if (library.name?.contains("com.vaadin:") == true) {
+                        hasVaadin = true
+                    }
+                    true
+                }
+            }
+            return hasVaadin
         }
 
     }

--- a/src/main/kotlin/com/vaadin/plugin/utils/VaadinProjectUtil.kt
+++ b/src/main/kotlin/com/vaadin/plugin/utils/VaadinProjectUtil.kt
@@ -24,6 +24,8 @@ class VaadinProjectUtil {
 
         private val LOG: Logger = Logger.getInstance(VaadinProjectUtil::class.java)
 
+        private const val VAADIN_LIB_PREFIX = "com.vaadin:"
+
         val PROJECT_DOWNLOADED_PROP_KEY = Key<GraphProperty<Boolean>>("vaadin_project_downloaded")
 
         val PROJECT_MODEL_PROP_KEY = Key<GraphProperty<DownloadableModel?>>("vaadin_project_model")
@@ -76,7 +78,7 @@ class VaadinProjectUtil {
             var hasVaadin = false
             ModuleManager.getInstance(project).modules.forEach { module ->
                 ModuleRootManager.getInstance(module).orderEntries().forEachLibrary { library: Library ->
-                    if (library.name?.contains("com.vaadin:") == true) {
+                    if (library.name?.contains(VAADIN_LIB_PREFIX) == true) {
                         hasVaadin = true
                     }
                     true

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -39,7 +39,8 @@
     <extensions defaultExtensionNs="com.intellij">
         <!-- Vaadin Copilot -->
         <notificationGroup id="Vaadin Copilot" displayType="BALLOON"/>
-        <postStartupActivity implementation="com.vaadin.plugin.copilot.activity.CopilotPostStartupProjectActivity"/>
+        <backgroundPostStartupActivity
+                implementation="com.vaadin.plugin.copilot.activity.CopilotPostStartupProjectActivity"/>
         <errorHandler implementation="com.vaadin.plugin.copilot.CopilotErrorHandler"/>
         <statusBarWidgetFactory implementation="com.vaadin.plugin.copilot.CopilotStatusBarWidgetFactory"
                                 id="CopilotStatusBarWidgetFactory" order="last"/>


### PR DESCRIPTION
Use IntelliJ API to detect Vaadin dependency

Tested with both Maven and Gradle based projects