### PR TITLE
feat: add debug using hotswap to run toolbar

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/actions/DebugUsingHotSwapAgentAction.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/DebugUsingHotSwapAgentAction.kt
@@ -1,0 +1,18 @@
+package com.vaadin.plugin.actions
+
+import com.intellij.execution.Executor
+import com.intellij.execution.ExecutorRegistry
+import com.intellij.execution.dashboard.actions.ExecutorAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.vaadin.plugin.hotswapagent.HotswapAgentExecutor
+
+class DebugUsingHotSwapAgentAction : ExecutorAction() {
+    override fun update(p0: AnActionEvent, p1: Boolean) {
+
+    }
+
+    override fun getExecutor(): Executor {
+        return ExecutorRegistry.getInstance().getExecutorById(HotswapAgentExecutor.ID)!!
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -74,6 +74,15 @@
                 text="HotSwap: Install or update"
                 description="Installs or updates hotswap-agent.jar">
         </action>
+        <action
+                id="HotSwap.debug"
+                class="com.vaadin.plugin.actions.DebugUsingHotSwapAgentAction"
+                text="Debug using HotSwapAgent"
+                icon="vaadin/icons/swap.svg">
+            <add-to-group group-id="RunDashboardContentToolbar"
+                          relative-to-action="RunDashboard.Debug"
+                          anchor="after"/>
+        </action>
     </actions>
 
 </idea-plugin>


### PR DESCRIPTION
Now you can Debug with HotSwapAgent from Services menu:

![image](https://github.com/user-attachments/assets/7b830a42-89ef-48d3-b555-828163eee1d7)

Fixes #76 
