### PR TITLE
fix: Turn off frame deactivation policy for Spring apps

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/hotswapagent/HotswapAgentProgramPatcher.kt
+++ b/src/main/kotlin/com/vaadin/plugin/hotswapagent/HotswapAgentProgramPatcher.kt
@@ -5,10 +5,14 @@ import com.intellij.execution.JavaRunConfigurationBase
 import com.intellij.execution.configurations.JavaParameters
 import com.intellij.execution.configurations.RunProfile
 import com.intellij.execution.runners.JavaProgramPatcher
+import com.intellij.openapi.diagnostic.Logger
 import com.vaadin.plugin.utils.VaadinHomeUtil
 
 
 class HotswapAgentProgramPatcher : JavaProgramPatcher() {
+
+    private val LOG: Logger = Logger.getInstance(HotswapAgentProgramPatcher::class.java)
+
     override fun patchJavaParameters(executor: Executor?, runProfile: RunProfile?, javaParameters: JavaParameters?) {
         if (executor !is HotswapAgentExecutor) {
             return
@@ -21,6 +25,9 @@ class HotswapAgentProgramPatcher : JavaProgramPatcher() {
         }
         val module = runProfile.configurationModule?.module ?: return
 
+        if (runProfile.javaClass.simpleName == "SpringBootApplicationRunConfiguration") {
+            turnOffFrameDeactivationPolicy(runProfile);
+        }
         if (!JdkUtil.isJetbrainsRuntime(javaParameters.jdk)) {
             // Use the bundled Jetbrains Runtime
             javaParameters.jdk = JdkUtil.getCompatibleJetbrainsJdk(module)
@@ -50,5 +57,20 @@ class HotswapAgentProgramPatcher : JavaProgramPatcher() {
         paramsList.add("-javaagent:$agentInHome")
     }
 
+    private fun turnOffFrameDeactivationPolicy(runProfile: JavaRunConfigurationBase) {
+        try {
+            val getOptions = runProfile.javaClass.getDeclaredMethod("getOptions")
+            getOptions.trySetAccessible();
+            var options = getOptions.invoke(runProfile);
+            var policy = options.javaClass.getDeclaredField("frameDeactivationUpdatePolicy\$delegate")
+            policy.trySetAccessible();
+
+            val prop = policy.get(options);
+
+            prop.javaClass.getMethod("parseAndSetValue", String::class.java).invoke(prop, null);
+        } catch (e: Exception) {
+            LOG.debug("Failed to turn off frame deactivation policy", e)
+        }
+    }
 }
 


### PR DESCRIPTION
The default value for frame deactivation is to update classes and resources.

This causes an extra update when going from IntelliJ to the browser which either does nothing or then does an extra hotswap of some files, as described in https://github.com/vaadin/flow/issues/19971

Fixes https://github.com/vaadin/flow/issues/19971
