### PR TITLE
chore: increase until to 243.*

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,7 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
 tasks {
     patchPluginXml {
         sinceBuild.set("233")
-        untilBuild.set("242.*")
+        untilBuild.set("243.*")
     }
 
     signPlugin {


### PR DESCRIPTION
Hello Vaadin Ltd,

We noticed that due to a limited Until range, the following plugins will not be compatible with the upcoming IDE version (2024.3):
[Vaadin](https://plugins.jetbrains.com/plugin/23758-vaadin)
The EAP version was just released, so you have time to address the issue by uploading a new version with a higher or unlimited 'Until Build' setting.

We kindly suggest that you adjust the compatibility range to enable current users to continue enjoying the functionalities of your plugin without any interruptions.

Moreover, updating the compatibility settings will also make your plugin discoverable to new users who are exploring the latest version of our IDE.

Please feel free to reach out if you have any questions or require further assistance.

You can unsubscribe from future notifications about the specific plugin on the plugin page, by clicking the subscription button (bell) in the top right-hand corner of the plugin page.

Best regards,
JetBrains Marketplace Team