### PR TITLE
chore: add to debugger toolbar, rerun label

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/actions/DebugUsingHotSwapAgentAction.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/DebugUsingHotSwapAgentAction.kt
@@ -5,9 +5,19 @@ import com.intellij.execution.ExecutorRegistry
 import com.intellij.execution.dashboard.actions.ExecutorAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.vaadin.plugin.hotswapagent.HotswapAgentExecutor
+import com.vaadin.plugin.utils.VaadinIcons
 
 class DebugUsingHotSwapAgentAction : ExecutorAction() {
-    override fun update(p0: AnActionEvent, p1: Boolean) {}
+    override fun update(event: AnActionEvent, isRunning: Boolean) {
+        if (isRunning) {
+            event.presentation.text = "Rerun using HotSwapAgent"
+            // TODO: https://github.com/vaadin/intellij-plugin/issues/101
+            event.presentation.icon = VaadinIcons.DEBUG_HOTSWAP
+        } else {
+            event.presentation.text = "Debug using HotSwapAgent"
+            event.presentation.icon = VaadinIcons.DEBUG_HOTSWAP
+        }
+    }
 
     override fun getExecutor(): Executor {
         return ExecutorRegistry.getInstance().getExecutorById(HotswapAgentExecutor.ID)!!

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -82,6 +82,9 @@
             <add-to-group group-id="RunDashboardContentToolbar"
                           relative-to-action="RunDashboard.Debug"
                           anchor="after"/>
+            <add-to-group group-id="XDebugger.ToolWindow.TopToolbar3"
+                          relative-to-action="Rerun"
+                          anchor="after" />
         </action>
     </actions>
 


### PR DESCRIPTION
Added Debug/Rerun using HotSwap to debugger toolbar:

<img width="1225" alt="image" src="https://github.com/user-attachments/assets/667a3e9d-6a0f-4525-bd64-58e002af08f2">

When debugging with hotswap is running, label now displays "Rerun":

<img width="510" alt="image" src="https://github.com/user-attachments/assets/83a2bc1e-6b3f-4dd1-9098-d7149cc5bb44">

Fixes #92 