### PR TITLE
Do not create copilot dotfile if project is not opened yet

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
+++ b/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
@@ -13,7 +13,7 @@ class VaadinProjectDetector : ModuleRootListener, ProjectActivity {
     private val LOG: Logger = Logger.getInstance(VaadinProjectDetector::class.java)
 
     override fun rootsChanged(event: ModuleRootEvent) {
-        if (isVaadinProject(event.project) && event.project.isOpen) {
+        if (event.project.isOpen && isVaadinProject(event.project)) {
             doNotifyAboutVaadinProject(event.project)
             LOG.info("Vaadin detected in dependencies of " + event.project.name)
         }

--- a/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
+++ b/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
@@ -13,7 +13,7 @@ class VaadinProjectDetector : ModuleRootListener, ProjectActivity {
     private val LOG: Logger = Logger.getInstance(VaadinProjectDetector::class.java)
 
     override fun rootsChanged(event: ModuleRootEvent) {
-        if (isVaadinProject(event.project)) {
+        if (isVaadinProject(event.project) && event.project.isOpen) {
             doNotifyAboutVaadinProject(event.project)
             LOG.info("Vaadin detected in dependencies of " + event.project.name)
         }


### PR DESCRIPTION
Library roots can be changed before project is loaded. We need to discard those events on not opened project. Project post startup activity will trigger event if ready. 

Fixes #100 