### PR TITLE
fix: better project base path detection

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
+++ b/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
@@ -11,9 +11,9 @@ import com.intellij.openapi.vfs.VfsUtil
 import com.vaadin.plugin.listeners.VaadinProjectListener
 import com.vaadin.plugin.utils.VaadinProjectUtil
 import com.vaadin.plugin.utils.VaadinProjectUtil.Companion.findVaadinModule
+import java.io.File
 import org.jetbrains.idea.maven.project.MavenProjectsManager
 import org.jetbrains.plugins.gradle.settings.GradleSettings
-import java.io.File
 
 class VaadinProjectDetector : ModuleRootListener, ProjectActivity {
 

--- a/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
+++ b/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.roots.ModuleRootEvent
 import com.intellij.openapi.roots.ModuleRootListener
 import com.intellij.openapi.startup.ProjectActivity
@@ -70,7 +71,8 @@ class VaadinProjectDetector : ModuleRootListener, ProjectActivity {
             return externalRootPath
         }
 
-        LOG.info("Project base path: ${project.basePath}")
-        return project.basePath
+        val guessedPath = project.guessProjectDir()?.path
+        LOG.info("Project guessed path: $guessedPath")
+        return guessedPath
     }
 }

--- a/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
+++ b/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
@@ -1,14 +1,19 @@
 package com.vaadin.plugin
 
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
+import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootEvent
 import com.intellij.openapi.roots.ModuleRootListener
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.openapi.vfs.VfsUtil
 import com.vaadin.plugin.listeners.VaadinProjectListener
 import com.vaadin.plugin.utils.VaadinProjectUtil
 import com.vaadin.plugin.utils.VaadinProjectUtil.Companion.findVaadinModule
+import org.jetbrains.idea.maven.project.MavenProjectsManager
+import org.jetbrains.plugins.gradle.settings.GradleSettings
+import java.io.File
 
 class VaadinProjectDetector : ModuleRootListener, ProjectActivity {
 
@@ -26,10 +31,46 @@ class VaadinProjectDetector : ModuleRootListener, ProjectActivity {
 
     private fun detectVaadinAndNotify(project: Project) {
         findVaadinModule(project)?.let { module ->
-            project.putUserData(
-                VaadinProjectUtil.VAADIN_MODULE_ROOTS, ModuleRootManager.getInstance(module).contentRoots)
-            project.messageBus.syncPublisher(VaadinProjectListener.TOPIC).vaadinProjectDetected(project)
             LOG.info("Detected Vaadin module: ${module.name}")
+            val projectRoot = findProjectRoot(project, module)
+            if (projectRoot == null) {
+                LOG.warn("Project root not found")
+                return@let
+            }
+            val projectRootFile = VfsUtil.findFileByIoFile(File(projectRoot), true)
+            if (projectRootFile == null) {
+                LOG.warn("Project root $projectRootFile is not accessible")
+                return@let
+            }
+            project.putUserData(VaadinProjectUtil.VAADIN_ROOT_MODULE_PATH_KEY, projectRootFile)
+            project.messageBus.syncPublisher(VaadinProjectListener.TOPIC).vaadinProjectDetected(project)
         }
+    }
+
+    private fun findProjectRoot(project: Project, module: Module): String? {
+        val maybeMavenProject = MavenProjectsManager.getInstance(project)
+        if (maybeMavenProject.isMavenizedProject) {
+            val rootDir = maybeMavenProject.rootProjects.iterator().next().directory
+            LOG.info("Maven project root: $rootDir")
+            return rootDir
+        }
+
+        val maybeGradle = GradleSettings.getInstance(project)
+        if (!maybeGradle.linkedProjectsSettings.isEmpty()) {
+            val externalProjectPath = maybeGradle.linkedProjectsSettings.iterator().next().externalProjectPath
+            if (externalProjectPath != null) {
+                LOG.info("Gradle project root: $externalProjectPath")
+                return externalProjectPath
+            }
+        }
+
+        val externalRootPath = ExternalSystemApiUtil.getExternalRootProjectPath(module)
+        if (externalRootPath != null) {
+            LOG.info("External system root: $externalRootPath")
+            return externalRootPath
+        }
+
+        LOG.info("Project base path: ${project.basePath}")
+        return project.basePath
     }
 }

--- a/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
@@ -125,9 +125,8 @@ class CopilotPluginUtil {
         }
 
         private fun getIdeaDir(project: Project): VirtualFile {
-            val roots = project.getUserData(VaadinProjectUtil.VAADIN_MODULE_ROOTS)
-            val firstRoot = roots!!.iterator().next()
-            return firstRoot.findOrCreateDirectory(IDEA_DIR)
+            val root = project.getUserData(VaadinProjectUtil.VAADIN_ROOT_MODULE_PATH_KEY)
+            return root!!.findOrCreateDirectory(IDEA_DIR)
         }
 
         private fun getDotFileDirectory(project: Project): PsiDirectory? {

--- a/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotVaadinProjectListener.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotVaadinProjectListener.kt
@@ -3,7 +3,8 @@ package com.vaadin.plugin.copilot.listeners
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.project.ProjectManagerListener
-import com.vaadin.plugin.copilot.CopilotPluginUtil
+import com.vaadin.plugin.copilot.CopilotPluginUtil.Companion.removeDotFile
+import com.vaadin.plugin.copilot.CopilotPluginUtil.Companion.saveDotFile
 import com.vaadin.plugin.listeners.VaadinProjectListener
 
 class CopilotVaadinProjectListener : VaadinProjectListener {
@@ -13,17 +14,9 @@ class CopilotVaadinProjectListener : VaadinProjectListener {
     override fun vaadinProjectDetected(project: Project) {
         if (!triggered) {
             triggered = true
-            createDotFile(project)
+            saveDotFile(project)
             removeDotFileOnExit(project)
         }
-    }
-
-    private fun createDotFile(project: Project) {
-        val dotFileDirectory = CopilotPluginUtil.getDotFileDirectory(project)
-        if (dotFileDirectory == null) {
-            CopilotPluginUtil.createIdeaDirectoryIfMissing(project)
-        }
-        CopilotPluginUtil.saveDotFile(project)
     }
 
     private fun removeDotFileOnExit(project: Project) {
@@ -32,7 +25,7 @@ class CopilotVaadinProjectListener : VaadinProjectListener {
                 project,
                 object : ProjectManagerListener {
                     override fun projectClosing(project: Project) {
-                        CopilotPluginUtil.removeDotFile(project)
+                        removeDotFile(project)
                     }
                 },
             )

--- a/src/main/kotlin/com/vaadin/plugin/utils/VaadinProjectUtil.kt
+++ b/src/main/kotlin/com/vaadin/plugin/utils/VaadinProjectUtil.kt
@@ -1,6 +1,7 @@
 package com.vaadin.plugin.utils
 
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.observable.properties.GraphProperty
 import com.intellij.openapi.project.Project
@@ -8,6 +9,7 @@ import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.libraries.Library
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.util.download.DownloadableFileService
 import com.intellij.util.io.ZipUtil
@@ -25,6 +27,8 @@ class VaadinProjectUtil {
         private val LOG: Logger = Logger.getInstance(VaadinProjectUtil::class.java)
 
         private const val VAADIN_LIB_PREFIX = "com.vaadin:"
+
+        val VAADIN_MODULE_ROOTS = Key<Array<VirtualFile>>("vaadin_module_roots")
 
         val PROJECT_DOWNLOADED_PROP_KEY = Key<GraphProperty<Boolean>>("vaadin_project_downloaded")
 
@@ -75,11 +79,11 @@ class VaadinProjectUtil {
             }
         }
 
-        fun isVaadinProject(project: Project): Boolean {
-            return ModuleManager.getInstance(project).modules.any { isVaadinModule(it) }
+        fun findVaadinModule(project: Project): Module? {
+            return ModuleManager.getInstance(project).modules.find { isVaadinModule(it) }
         }
 
-        fun isVaadinModule(module: com.intellij.openapi.module.Module): Boolean {
+        private fun isVaadinModule(module: Module): Boolean {
             var hasVaadin = false
             ModuleRootManager.getInstance(module).orderEntries().forEachLibrary { library: Library ->
                 if (library.name?.contains(VAADIN_LIB_PREFIX) == true) {

--- a/src/main/kotlin/com/vaadin/plugin/utils/VaadinProjectUtil.kt
+++ b/src/main/kotlin/com/vaadin/plugin/utils/VaadinProjectUtil.kt
@@ -28,7 +28,7 @@ class VaadinProjectUtil {
 
         private const val VAADIN_LIB_PREFIX = "com.vaadin:"
 
-        val VAADIN_MODULE_ROOTS = Key<Array<VirtualFile>>("vaadin_module_roots")
+        val VAADIN_ROOT_MODULE_PATH_KEY = Key<VirtualFile>("vaadin_root_module_path")
 
         val PROJECT_DOWNLOADED_PROP_KEY = Key<GraphProperty<Boolean>>("vaadin_project_downloaded")
 


### PR DESCRIPTION
## Description

Do not use `project.basePath` for detecting project root.

From [IntelliJ java docs](https://github.com/JetBrains/intellij-community/blob/68c03c29f1e92f2f4b62b488ec750791ddf02c20/platform/core-api/src/com/intellij/openapi/project/Project.java#L52):

```
   * <p>It's <b>strongly recommended</b> to use other methods instead of this one (see {@link #getBaseDir()} for alternatives. Most
   * probably any use of this method in production code may lead to unexpected results for some projects (e.g. if {@code .idea} directory is
   * stored not near the project files).
   * </p>
```

Fixes #47