### PR TITLE
chore: typo in notification group

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/listeners/ConfigurationCheckVaadinProjectListener.kt
+++ b/src/main/kotlin/com/vaadin/plugin/listeners/ConfigurationCheckVaadinProjectListener.kt
@@ -25,7 +25,7 @@ import com.vaadin.plugin.utils.VaadinIcons
 class ConfigurationCheckVaadinProjectListener : VaadinProjectListener {
 
     companion object {
-        const val NOTIFICATION_GROUP = "Vaadin Configuration Check"
+        const val NOTIFICATION_GROUP = "Vaadin configuration check"
 
         val VCS_CONFIRMATION_CONFIGURABLE =
             VcsBundle.message("configurable.VcsGeneralConfigurationConfigurable.display.name")


### PR DESCRIPTION
After adjusting notification group name not to use title case I forgot to adjust that one also. And it seems it is case-sensitive.