### PR TITLE
fix: CopilotUndoManager service for tracking actions on save

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -19,8 +19,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: gradle
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
       - name: Check Spotless
         run: ./gradlew spotlessCheck
       - name: Run Unit Tests
@@ -37,8 +35,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: gradle
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
       - name: Build plugin
         run: ./gradlew --no-configuration-cache buildPlugin
       - uses: actions/upload-artifact@v4.3.3
@@ -64,7 +60,5 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: gradle
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
       - name: Verify plugin
         run: ./gradlew --no-configuration-cache verifyPlugin

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -23,6 +23,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
       - name: Check Spotless
         run: ./gradlew spotlessCheck
+      - name: Run Unit Tests
+        run: ./gradlew test
 
   buildPlugin:
     runs-on: ubuntu-latest

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,11 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="kotlin">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
   id("org.jetbrains.kotlin.jvm") version "1.9.21"
   id("org.jetbrains.intellij.platform") version "2.0.0"
   id("com.diffplug.spotless") version "7.0.0.BETA2"
+
+  id("com.adarshr.test-logger") version "4.0.0"
 }
 
 group = "com.vaadin"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+
 plugins {
   id("java")
   id("org.jetbrains.kotlin.jvm") version "1.9.21"
@@ -48,7 +50,12 @@ dependencies {
     pluginVerifier()
     zipSigner()
     instrumentationTools()
+
+    testFramework(TestFrameworkType.Platform)
   }
+
+  testImplementation(kotlin("test"))
+  testImplementation("junit:junit:4.13.2")
 }
 
 configure<com.diffplug.gradle.spotless.SpotlessExtension> {
@@ -84,4 +91,6 @@ tasks {
     channels.set(listOf(publishChannel))
     token.set(System.getenv("PUBLISH_TOKEN"))
   }
+
+  test { useJUnitPlatform() }
 }

--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/AbstractHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/AbstractHandler.kt
@@ -73,7 +73,7 @@ abstract class AbstractHandler(val project: Project) : Handler {
         FileEditorManager.getInstance(project).openTextEditor(openFileDescriptor, false)
     }
 
-    private fun notifyUndoManager(vfsFile: VirtualFile) {
+    fun notifyUndoManager(vfsFile: VirtualFile) {
         getCopilotUndoManager().fileWritten(vfsFile)
     }
 

--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/AbstractHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/AbstractHandler.kt
@@ -5,10 +5,13 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.findDocument
 import com.intellij.psi.PsiDocumentManager
 import com.vaadin.plugin.copilot.CopilotPluginUtil
+import com.vaadin.plugin.copilot.service.CopilotUndoManager
 import io.netty.handler.codec.http.HttpResponseStatus
 import java.io.File
 
@@ -58,10 +61,30 @@ abstract class AbstractHandler(val project: Project) : Handler {
         return FileEditorWrapper(editors.first(), project, false)
     }
 
+    open fun postSave(vfsFile: VirtualFile) {
+        LOG.info("File $vfsFile contents saved")
+        notifyUndoManager(vfsFile)
+        commitAndFlush(vfsFile.findDocument())
+        openFileInEditor(vfsFile)
+    }
+
+    private fun openFileInEditor(vfsFile: VirtualFile) {
+        val openFileDescriptor = OpenFileDescriptor(project, vfsFile)
+        FileEditorManager.getInstance(project).openTextEditor(openFileDescriptor, false)
+    }
+
+    private fun notifyUndoManager(vfsFile: VirtualFile) {
+        getCopilotUndoManager().fileWritten(vfsFile)
+    }
+
     fun commitAndFlush(vfsDoc: Document?) {
         if (vfsDoc != null) {
             PsiDocumentManager.getInstance(project).commitDocument(vfsDoc)
             FileDocumentManager.getInstance().saveDocuments(vfsDoc::equals)
         }
+    }
+
+    fun getCopilotUndoManager(): CopilotUndoManager {
+        return project.getService(CopilotUndoManager::class.java)
     }
 }

--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/UndoHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/UndoHandler.kt
@@ -3,18 +3,17 @@ package com.vaadin.plugin.copilot.handler
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.command.impl.UndoManagerImpl
+import com.intellij.openapi.command.undo.UndoManager
+import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.findDocument
-import com.vaadin.plugin.actions.VaadinCompileOnSaveAction
 import java.io.File
 
 open class UndoHandler(project: Project, data: Map<String, Any>) : AbstractHandler(project) {
 
-    private val copilotActionPrefix = "_Undo Vaadin Copilot"
-
-    protected val vfsFiles: ArrayList<VirtualFile> = ArrayList()
+    private val vfsFiles: ArrayList<VirtualFile> = ArrayList()
 
     init {
         val paths = data["files"] as Collection<String>
@@ -30,24 +29,47 @@ open class UndoHandler(project: Project, data: Map<String, Any>) : AbstractHandl
 
     override fun run(): HandlerResponse {
         for (vfsFile in vfsFiles) {
+            val count = getOpsCount(vfsFile)
+            if (count == 0) {
+                continue
+            }
+
             runInEdt {
                 getEditorWrapper(vfsFile).use { wrapper ->
                     val undoManager = UndoManagerImpl.getInstance(project)
                     val editor = wrapper.getFileEditor()
                     runWriteAction {
-                        if (undoManager.isUndoAvailable(editor)) {
-                            val undo = undoManager.getUndoActionNameAndDescription(editor).first
-                            if (undo.startsWith(copilotActionPrefix)) {
-                                undoManager.undo(editor)
-                                commitAndFlush(vfsFile.findDocument())
-                                LOG.info("$undo performed on ${vfsFile.path}")
-                                VaadinCompileOnSaveAction().compile(project, vfsFile)
+                        try {
+                            before(vfsFile)
+                            var i = 0
+                            while (i++ < count) {
+                                runManagerAction(undoManager, editor)
                             }
+                            commitAndFlush(vfsFile.findDocument())
+                        } finally {
+                            after(vfsFile)
                         }
                     }
                 }
             }
         }
         return RESPONSE_OK
+    }
+
+    open fun getOpsCount(vfsFile: VirtualFile): Int {
+        return getCopilotUndoManager().getUndoCount(vfsFile)
+    }
+
+    open fun before(vfsFile: VirtualFile) {
+        getCopilotUndoManager().undoStart(vfsFile)
+    }
+
+    open fun runManagerAction(undoManager: UndoManager, editor: FileEditor) {
+        undoManager.undo(editor)
+    }
+
+    open fun after(vfsFile: VirtualFile) {
+        getCopilotUndoManager().undoDone(vfsFile)
+        LOG.info("$vfsFile undo performed")
     }
 }

--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteBase64FileHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteBase64FileHandler.kt
@@ -2,24 +2,12 @@ package com.vaadin.plugin.copilot.handler
 
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiManager
-import java.io.File
-import java.nio.file.Files
 import java.util.Base64
 
 class WriteBase64FileHandler(project: Project, data: Map<String, Any>) : WriteFileHandler(project, data) {
 
     override fun doWrite(vfsFile: VirtualFile?, doc: Document?, content: String) {
         vfsFile?.setBinaryContent(Base64.getDecoder().decode(content))
-    }
-
-    override fun doCreate(ioFile: File, content: String): PsiFile {
-        Files.createFile(ioFile.toPath())
-        val vfsFile = VfsUtil.findFileByIoFile(ioFile, true)
-        doWrite(vfsFile!!, null, content)
-        return PsiManager.getInstance(project).findFile(vfsFile)!!
     }
 }

--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteFileHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteFileHandler.kt
@@ -7,8 +7,6 @@ import com.intellij.openapi.command.UndoConfirmationPolicy
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.actionSystem.DocCommandGroupId
-import com.intellij.openapi.fileEditor.FileEditorManager
-import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.Strings
@@ -67,9 +65,7 @@ open class WriteFileHandler(project: Project, data: Map<String, Any>) : Abstract
                     {
                         WriteCommandAction.runWriteCommandAction(project) {
                             doWrite(vfsFile, it, content)
-                            commitAndFlush(it)
-                            LOG.info("File $ioFile contents saved")
-                            openFileInEditor(vfsFile)
+                            postSave(vfsFile)
                         }
                     },
                     undoLabel ?: "Vaadin Copilot Write File",
@@ -99,9 +95,7 @@ open class WriteFileHandler(project: Project, data: Map<String, Any>) : Abstract
                                 if (psiFile.containingDirectory == null) {
                                     psiDir.add(psiFile)
                                 }
-
-                                LOG.info("File $ioFile contents saved")
-                                VfsUtil.findFileByIoFile(ioFile, true)?.let { vfsFile -> openFileInEditor(vfsFile) }
+                                VfsUtil.findFileByIoFile(ioFile, true)?.let { vfsFile -> postSave(vfsFile) }
                             }
                         },
                         undoLabel ?: "Vaadin Copilot Write File",
@@ -110,11 +104,6 @@ open class WriteFileHandler(project: Project, data: Map<String, Any>) : Abstract
                     )
             }
         }
-    }
-
-    private fun openFileInEditor(vfsFile: VirtualFile) {
-        val openFileDescriptor = OpenFileDescriptor(project, vfsFile)
-        FileEditorManager.getInstance(project).openTextEditor(openFileDescriptor, false)
     }
 
     private fun getOrCreateParentDir(): VirtualFile? {

--- a/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteFileHandler.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/handler/WriteFileHandler.kt
@@ -1,22 +1,17 @@
 package com.vaadin.plugin.copilot.handler
 
 import com.intellij.openapi.application.runInEdt
-import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.command.UndoConfirmationPolicy
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.actionSystem.DocCommandGroupId
-import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.Strings
 import com.intellij.openapi.vfs.ReadonlyStatusHandler
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.findDocument
-import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiFileFactory
-import com.intellij.psi.PsiManager
 import com.vaadin.plugin.utils.IdeUtil
 import io.netty.handler.codec.http.HttpResponseStatus
 import java.io.File
@@ -76,47 +71,28 @@ open class WriteFileHandler(project: Project, data: Map<String, Any>) : Abstract
     }
 
     private fun create() {
-        val psiDir = runReadAction {
-            val parentDir = getOrCreateParentDir()
-            if (parentDir != null) {
-                return@runReadAction PsiManager.getInstance(project).findDirectory(parentDir)
-            }
-            return@runReadAction null
-        }
-
-        if (psiDir != null) {
-            runInEdt {
-                CommandProcessor.getInstance()
-                    .executeCommand(
-                        project,
-                        {
-                            WriteCommandAction.runWriteCommandAction(project) {
-                                val psiFile = doCreate(ioFile, content)
-                                if (psiFile.containingDirectory == null) {
-                                    psiDir.add(psiFile)
-                                }
-                                VfsUtil.findFileByIoFile(ioFile, true)?.let { vfsFile -> postSave(vfsFile) }
-                            }
-                        },
-                        undoLabel ?: "Vaadin Copilot Write File",
-                        null,
-                        UndoConfirmationPolicy.DO_NOT_REQUEST_CONFIRMATION,
-                    )
-            }
+        runInEdt {
+            CommandProcessor.getInstance()
+                .executeCommand(
+                    project,
+                    {
+                        WriteCommandAction.runWriteCommandAction(project) {
+                            val vfsFile = doCreate(ioFile, content)
+                            postSave(vfsFile)
+                        }
+                    },
+                    undoLabel ?: "Vaadin Copilot Write File",
+                    null,
+                    UndoConfirmationPolicy.DO_NOT_REQUEST_CONFIRMATION,
+                )
         }
     }
 
-    private fun getOrCreateParentDir(): VirtualFile? {
-        if (!ioFile.parentFile.exists() && !ioFile.parentFile.mkdirs()) {
-            LOG.warn("Cannot create parent directories for ${ioFile.parent}")
-            return null
-        }
-        return VfsUtil.findFileByIoFile(ioFile.parentFile, true)
-    }
-
-    open fun doCreate(ioFile: File, content: String): PsiFile {
-        val fileType = FileTypeManager.getInstance().getFileTypeByFileName(ioFile.name)
-        return PsiFileFactory.getInstance(project).createFileFromText(ioFile.name, fileType, content)
+    open fun doCreate(file: File, content: String): VirtualFile {
+        val parent = VfsUtil.createDirectories(file.parent)
+        val vfsFile = parent.createChildData(this, file.name)
+        doWrite(vfsFile, vfsFile.findDocument(), content)
+        return vfsFile
     }
 
     open fun doWrite(vfsFile: VirtualFile?, doc: Document?, content: String) {

--- a/src/main/kotlin/com/vaadin/plugin/copilot/service/CopilotUndoManager.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/service/CopilotUndoManager.kt
@@ -1,0 +1,20 @@
+package com.vaadin.plugin.copilot.service
+
+import com.intellij.openapi.vfs.VirtualFile
+
+interface CopilotUndoManager {
+
+    fun fileWritten(file: VirtualFile)
+
+    fun getUndoCount(file: VirtualFile): Int
+
+    fun getRedoCount(file: VirtualFile): Int
+
+    fun undoStart(file: VirtualFile)
+
+    fun undoDone(file: VirtualFile)
+
+    fun redoStart(file: VirtualFile)
+
+    fun redoDone(file: VirtualFile)
+}

--- a/src/main/kotlin/com/vaadin/plugin/copilot/service/CopilotUndoManagerImpl.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/service/CopilotUndoManagerImpl.kt
@@ -1,0 +1,90 @@
+package com.vaadin.plugin.copilot.service
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import java.util.concurrent.locks.ReentrantLock
+
+@Service(Service.Level.PROJECT)
+class CopilotUndoManagerImpl(val project: Project) : CopilotUndoManager, Disposable {
+
+    companion object {
+        const val ACTIONS_ON_SAVE_WINDOW = 500 // ms window for actions on save
+    }
+
+    data class FileModification(val modified: Long, var count: Int) {
+        fun isCurrent(): Boolean {
+            return System.currentTimeMillis() - modified <= ACTIONS_ON_SAVE_WINDOW
+        }
+    }
+
+    private val undoStack: MutableMap<String, FileModification> = mutableMapOf()
+    private val redoStack: MutableMap<String, FileModification> = mutableMapOf()
+
+    private val lock = ReentrantLock()
+
+    private val bulkFileListener =
+        object : BulkFileListener {
+            override fun after(events: MutableList<out VFileEvent>) {
+                if (!lock.isLocked) {
+                    events
+                        .filter { ev -> ev.isFromSave }
+                        .forEach {
+                            if (undoStack.containsKey(it.path)) {
+                                val fileModification = undoStack[it.path]!!
+                                if (fileModification.isCurrent()) {
+                                    undoStack[it.path]!!.count += 1
+                                } else {
+                                    undoStack.remove(it.path)
+                                }
+                            }
+                        }
+                }
+            }
+        }
+
+    init {
+        project.messageBus.connect(this).subscribe(VirtualFileManager.VFS_CHANGES, bulkFileListener)
+    }
+
+    override fun fileWritten(file: VirtualFile) {
+        undoStack[file.path] = FileModification(System.currentTimeMillis(), 0)
+    }
+
+    override fun getUndoCount(file: VirtualFile): Int {
+        return undoStack[file.path]?.count ?: 0
+    }
+
+    override fun getRedoCount(file: VirtualFile): Int {
+        return redoStack[file.path]?.count ?: 0
+    }
+
+    override fun undoStart(file: VirtualFile) {
+        lock.lock()
+    }
+
+    override fun redoStart(file: VirtualFile) {
+        lock.lock()
+    }
+
+    override fun undoDone(file: VirtualFile) {
+        redoStack[file.path] = FileModification(System.currentTimeMillis(), undoStack[file.path]!!.count)
+        undoStack.remove(file.path)
+        lock.unlock()
+    }
+
+    override fun redoDone(file: VirtualFile) {
+        undoStack[file.path] = FileModification(System.currentTimeMillis(), redoStack[file.path]!!.count)
+        redoStack.remove(file.path)
+        lock.unlock()
+    }
+
+    override fun dispose() {
+        undoStack.clear()
+        redoStack.clear()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -47,6 +47,9 @@
         <statusBarWidgetFactory implementation="com.vaadin.plugin.copilot.CopilotStatusBarWidgetFactory"
                                 id="CopilotStatusBarWidgetFactory" order="last"/>
         <httpRequestHandler implementation="com.vaadin.plugin.copilot.service.CopilotRestService"/>
+        <projectService
+                serviceInterface="com.vaadin.plugin.copilot.service.CopilotUndoManager"
+                serviceImplementation="com.vaadin.plugin.copilot.service.CopilotUndoManagerImpl"/>
 
         <!-- Vaadin Project Wizard -->
         <moduleBuilder id="VaadinModuleBuilder" builderClass="com.vaadin.plugin.module.VaadinProjectBuilderAdapter"/>

--- a/src/test/kotlin/com/vaadin/plugin/copilot/service/CopilotUndoManagerTest.kt
+++ b/src/test/kotlin/com/vaadin/plugin/copilot/service/CopilotUndoManagerTest.kt
@@ -69,7 +69,7 @@ class CopilotUndoManagerTest : BasePlatformTestCase() {
         vfsFile = VfsUtil.findFileByIoFile(tempFile, false)
         assertTrue(vfsFile?.exists() == true)
         assertEquals(2, undoManager.getUndoCount(vfsFile!!))
-        assertEquals(0, undoManager.getRedoCount(vfsFile!!))
+        assertEquals(0, undoManager.getRedoCount(vfsFile))
     }
 
     @Test

--- a/src/test/kotlin/com/vaadin/plugin/copilot/service/CopilotUndoManagerTest.kt
+++ b/src/test/kotlin/com/vaadin/plugin/copilot/service/CopilotUndoManagerTest.kt
@@ -1,0 +1,195 @@
+package com.vaadin.plugin.copilot.service
+
+import ai.grazie.utils.mpp.UUID
+import com.intellij.openapi.application.runWriteActionAndWait
+import com.intellij.openapi.command.CommandProcessor
+import com.intellij.openapi.command.UndoConfirmationPolicy
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.findDocument
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.runInEdtAndWait
+import com.vaadin.plugin.copilot.handler.RedoHandler
+import com.vaadin.plugin.copilot.handler.UndoHandler
+import com.vaadin.plugin.copilot.handler.WriteFileHandler
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+class CopilotUndoManagerTest : BasePlatformTestCase() {
+
+    private lateinit var tempFile: File
+
+    private lateinit var undoManager: CopilotUndoManager
+
+    @BeforeEach
+    fun setup() {
+        super.setUp()
+        tempFile = File("${project.basePath}/${UUID.random().text}.tmp")
+        tempFile.deleteOnExit()
+        Files.createDirectories(Path.of(project.basePath))
+        undoManager = project.getService(CopilotUndoManager::class.java)
+    }
+
+    @AfterEach
+    fun teardown() {
+        super.tearDown()
+    }
+
+    @Test
+    fun test_newFile_createUndoRedo() {
+        callFileWriteHandler(tempFile.path, "Some changes")
+
+        var vfsFile = VfsUtil.findFileByIoFile(tempFile, false)
+        assertTrue(vfsFile?.exists() == true)
+
+        assertEquals(1, undoManager.getUndoCount(vfsFile!!))
+
+        // simulate save action
+        writeFile(vfsFile, "Updated Content", "Format On Save")
+        assertEquals(2, undoManager.getUndoCount(vfsFile))
+        assertEquals(0, undoManager.getRedoCount(vfsFile))
+
+        // undo should remove file
+        callUndoHandler(tempFile.path)
+        assertEquals(0, undoManager.getUndoCount(vfsFile))
+        assertEquals(2, undoManager.getRedoCount(vfsFile))
+        vfsFile = VfsUtil.findFileByIoFile(tempFile, false)
+        assertTrue(vfsFile == null)
+
+        // redo should recreate it
+        callRedoHandler(tempFile.path)
+
+        vfsFile = VfsUtil.findFileByIoFile(tempFile, false)
+        assertTrue(vfsFile?.exists() == true)
+        assertEquals(2, undoManager.getUndoCount(vfsFile!!))
+        assertEquals(0, undoManager.getRedoCount(vfsFile!!))
+    }
+
+    @Test
+    fun test_existingFile_writeUndoRedo() {
+        tempFile.createNewFile()
+        Files.writeString(tempFile.toPath(), "Original Content")
+
+        val vfsFile = VfsUtil.findFileByIoFile(tempFile, false)!!
+        assertTrue(vfsFile.exists())
+
+        callFileWriteHandler(vfsFile.path, "Some changes")
+
+        assertEquals(1, undoManager.getUndoCount(vfsFile))
+
+        // simulate save action
+        writeFile(vfsFile, "Updated Content", "Format On Save")
+        assertEquals(2, undoManager.getUndoCount(vfsFile))
+        assertEquals(0, undoManager.getRedoCount(vfsFile))
+
+        callUndoHandler(vfsFile.path)
+        assertEquals(0, undoManager.getUndoCount(vfsFile))
+        assertEquals(2, undoManager.getRedoCount(vfsFile))
+
+        callRedoHandler(vfsFile.path)
+        assertEquals(2, undoManager.getUndoCount(vfsFile))
+        assertEquals(0, undoManager.getRedoCount(vfsFile))
+
+        runWriteActionAndWait { vfsFile.delete(this) }
+    }
+
+    @Test
+    fun testExistingFile_multipleUndo() {
+        tempFile.createNewFile()
+        Files.writeString(tempFile.toPath(), "Original Content")
+
+        val vfsFile = VfsUtil.findFileByIoFile(tempFile, false)!!
+        assertTrue(vfsFile.exists())
+
+        // write and format first time
+        callFileWriteHandler(vfsFile.path, "Change      one")
+        writeFile(vfsFile, "Change one", "Format On Save")
+
+        // idle time
+        Thread.sleep(1000)
+
+        // write and format second time
+        callFileWriteHandler(vfsFile.path, "Change      two")
+        writeFile(vfsFile, "Change two", "Format On Save")
+
+        // idle time
+        Thread.sleep(1000)
+
+        // write and format third time
+        callFileWriteHandler(vfsFile.path, "Change      three")
+        writeFile(vfsFile, "Change three", "Format On Save")
+
+        // 3 Copilot consecutive operations -> all should be possible to undo
+
+        // call undo first time
+        callUndoHandler(vfsFile.path)
+        assertEquals(2, undoManager.getUndoCount(vfsFile))
+        assertEquals(2, undoManager.getRedoCount(vfsFile))
+
+        // call undo second time
+        callUndoHandler(vfsFile.path)
+        assertEquals(2, undoManager.getUndoCount(vfsFile))
+        assertEquals(2, undoManager.getRedoCount(vfsFile))
+
+        // call undo third time
+        callUndoHandler(vfsFile.path)
+        assertEquals(0, undoManager.getUndoCount(vfsFile))
+        assertEquals(2, undoManager.getRedoCount(vfsFile))
+    }
+
+    private fun callFileWriteHandler(file: String, text: String) {
+        val data = mapOf<String, Any>("content" to text, "undoLabel" to "Vaadin File Write", "file" to file)
+        runInEdtAndWait {
+            val response = WriteFileHandler(project, data).run()
+            assertEquals(200, response.status.code())
+        }
+    }
+
+    private fun callUndoHandler(file: String) {
+        val data = mapOf<String, Any>("files" to listOf(file))
+        runInEdtAndWait {
+            val response = UndoHandler(project, data).run()
+            assertEquals(200, response.status.code())
+        }
+    }
+
+    private fun callRedoHandler(file: String) {
+        val data = mapOf<String, Any>("files" to listOf(file))
+        runInEdtAndWait {
+            val response = RedoHandler(project, data).run()
+            assertEquals(200, response.status.code())
+        }
+    }
+
+    private fun commitAndFlush(doc: Document) {
+        PsiDocumentManager.getInstance(project).commitDocument(doc)
+        FileDocumentManager.getInstance().saveDocuments(doc::equals)
+    }
+
+    private fun writeFile(vfsFile: VirtualFile, content: String, undoLabel: String = "Test Write") {
+        runInEdtAndWait {
+            CommandProcessor.getInstance()
+                .executeCommand(
+                    project,
+                    {
+                        runWriteActionAndWait {
+                            vfsFile.findDocument()!!.let { doc ->
+                                doc.setText(content)
+                                commitAndFlush(doc)
+                            }
+                        }
+                    },
+                    undoLabel,
+                    null,
+                    UndoConfirmationPolicy.DO_NOT_REQUEST_CONFIRMATION,
+                )
+        }
+    }
+}

--- a/src/test/kotlin/com/vaadin/plugin/copilot/service/CopilotUndoManagerTest.kt
+++ b/src/test/kotlin/com/vaadin/plugin/copilot/service/CopilotUndoManagerTest.kt
@@ -15,12 +15,12 @@ import com.intellij.testFramework.runInEdtAndWait
 import com.vaadin.plugin.copilot.handler.RedoHandler
 import com.vaadin.plugin.copilot.handler.UndoHandler
 import com.vaadin.plugin.copilot.handler.WriteFileHandler
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class CopilotUndoManagerTest : BasePlatformTestCase() {
 


### PR DESCRIPTION
## Description

Use approach similar to VS Code plugin to track file changes in our own service. Assumed that file writes that happen after given time window are invoked by IDE as save actions. Window size set to 1000 ms.