### PR TITLE
fix: Do not use write locking access when running in background

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
@@ -3,7 +3,7 @@ package com.vaadin.plugin.actions
 import com.intellij.debugger.DebuggerManagerEx
 import com.intellij.debugger.ui.HotSwapUI
 import com.intellij.ide.actionsOnSave.impl.ActionsOnSaveFileDocumentManagerListener
-import com.intellij.openapi.application.WriteIntentReadAction
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
@@ -43,7 +43,7 @@ class VaadinCompileOnSaveAction : ActionsOnSaveFileDocumentManagerListener.Actio
                     val session = DebuggerManagerEx.getInstanceEx(project).context.debuggerSession
                     if (session != null) {
                         LOG.info("${vfsFile.name} compiling...")
-                        WriteIntentReadAction.run { HotSwapUI.getInstance(project).compileAndReload(session, vfsFile) }
+                        ReadAction.run<Exception> { HotSwapUI.getInstance(project).compileAndReload(session, vfsFile) }
                     }
                 }
             }


### PR DESCRIPTION
`WriteIntentReadAction` cannot be used in background threads. Read action is enough for calling HotSwapUI. 