### PR TITLE
fix: Make it less likely to trigger multiple compiles

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
@@ -50,6 +50,7 @@ class VaadinCompileOnSaveAction : ActionsOnSaveFileDocumentManagerListener.Actio
                         val session = DebuggerManagerEx.getInstanceEx(project).context.debuggerSession
                         if (session != null) {
                             ReadAction.run<Throwable> {
+                                Thread.sleep(1);
                                 HotSwapUI.getInstance(project).compileAndReload(session, *javaFiles.toTypedArray())
                             }
                         }

--- a/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
@@ -50,7 +50,7 @@ class VaadinCompileOnSaveAction : ActionsOnSaveFileDocumentManagerListener.Actio
                         val session = DebuggerManagerEx.getInstanceEx(project).context.debuggerSession
                         if (session != null) {
                             ReadAction.run<Throwable> {
-                                Thread.sleep(1);
+                                Thread.sleep(1)
                                 HotSwapUI.getInstance(project).compileAndReload(session, *javaFiles.toTypedArray())
                             }
                         }


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/JBR-7850/Calling-compile-from-a-save-action-can-trigger-another-save-action

Fixes #147