### PR TITLE
chore: Removes untilBuild property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,7 +80,6 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
 tasks {
   patchPluginXml {
     sinceBuild.set("233")
-    untilBuild.set("243.*")
   }
 
   signPlugin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,9 +78,7 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
 }
 
 tasks {
-  patchPluginXml {
-    sinceBuild.set("233")
-  }
+  patchPluginXml { sinceBuild.set("233") }
 
   signPlugin {
     certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))


### PR DESCRIPTION
Removes max version limitation. Otherwise we need to bump it on each new intellij release.