### PR TITLE
ref: use hasLibraryClass to detect Vaadin projects

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
+++ b/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
@@ -1,28 +1,33 @@
 package com.vaadin.plugin
 
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootEvent
 import com.intellij.openapi.roots.ModuleRootListener
 import com.intellij.openapi.startup.ProjectActivity
 import com.vaadin.plugin.listeners.VaadinProjectListener
-import com.vaadin.plugin.utils.VaadinProjectUtil.Companion.isVaadinProject
+import com.vaadin.plugin.utils.hasVaadin
 
 class VaadinProjectDetector : ModuleRootListener, ProjectActivity {
 
     private val LOG: Logger = Logger.getInstance(VaadinProjectDetector::class.java)
 
     override fun rootsChanged(event: ModuleRootEvent) {
-        if (event.project.isOpen && isVaadinProject(event.project)) {
-            doNotifyAboutVaadinProject(event.project)
-            LOG.info("Vaadin detected in dependencies of " + event.project.name)
+        ReadAction.run<Throwable> {
+            if (event.project.isOpen && hasVaadin(event.project)) {
+                doNotifyAboutVaadinProject(event.project)
+                LOG.info("Vaadin detected in dependencies of " + event.project.name)
+            }
         }
     }
 
     override suspend fun execute(project: Project) {
-        if (isVaadinProject(project)) {
-            doNotifyAboutVaadinProject(project)
-            LOG.info("Vaadin detected during startup of " + project.name)
+        ReadAction.run<Throwable> {
+            if (hasVaadin(project)) {
+                doNotifyAboutVaadinProject(project)
+                LOG.info("Vaadin detected during startup of " + project.name)
+            }
         }
     }
 

--- a/src/main/kotlin/com/vaadin/plugin/endpoints/VaadinEndpointsProvider.kt
+++ b/src/main/kotlin/com/vaadin/plugin/endpoints/VaadinEndpointsProvider.kt
@@ -1,7 +1,12 @@
 package com.vaadin.plugin.endpoints
 
-import com.intellij.microservices.endpoints.*
+import com.intellij.microservices.endpoints.EndpointType
+import com.intellij.microservices.endpoints.EndpointsFilter
+import com.intellij.microservices.endpoints.EndpointsProvider
 import com.intellij.microservices.endpoints.EndpointsProvider.Status
+import com.intellij.microservices.endpoints.FrameworkPresentation
+import com.intellij.microservices.endpoints.HTTP_SERVER_TYPE
+import com.intellij.microservices.endpoints.ModuleEndpointsFilter
 import com.intellij.microservices.endpoints.presentation.HttpUrlPresentation
 import com.intellij.microservices.url.UrlPath
 import com.intellij.navigation.ItemPresentation
@@ -10,6 +15,7 @@ import com.intellij.openapi.util.ModificationTracker
 import com.intellij.psi.PsiElement
 import com.intellij.uast.UastModificationTracker
 import com.vaadin.plugin.utils.VaadinIcons
+import com.vaadin.plugin.utils.hasVaadin
 
 internal class VaadinEndpointsProvider : EndpointsProvider<VaadinRoute, VaadinRoute> {
     override val endpointType: EndpointType = HTTP_SERVER_TYPE
@@ -18,7 +24,7 @@ internal class VaadinEndpointsProvider : EndpointsProvider<VaadinRoute, VaadinRo
         FrameworkPresentation("Vaadin", "Vaadin Flow", VaadinIcons.VAADIN_BLUE)
 
     override fun getStatus(project: Project): Status {
-        if (hasVaadinFlow(project)) return Status.HAS_ENDPOINTS
+        if (hasVaadin(project)) return Status.HAS_ENDPOINTS
 
         return Status.UNAVAILABLE
     }
@@ -29,7 +35,7 @@ internal class VaadinEndpointsProvider : EndpointsProvider<VaadinRoute, VaadinRo
 
     override fun getEndpointGroups(project: Project, filter: EndpointsFilter): Iterable<VaadinRoute> {
         if (filter !is ModuleEndpointsFilter) return emptyList()
-        if (!hasVaadinFlow(filter.module)) return emptyList()
+        if (!hasVaadin(filter.module)) return emptyList()
 
         return findVaadinRoutes(project, filter.transitiveSearchScope)
     }

--- a/src/main/kotlin/com/vaadin/plugin/endpoints/VaadinModel.kt
+++ b/src/main/kotlin/com/vaadin/plugin/endpoints/VaadinModel.kt
@@ -1,7 +1,5 @@
 package com.vaadin.plugin.endpoints
 
-import com.intellij.java.library.JavaLibraryUtil.hasLibraryClass
-import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnchor
@@ -17,10 +15,6 @@ internal const val VAADIN_ROUTE = "com.vaadin.flow.router.Route"
 internal const val VAADIN_APP_SHELL_CONFIGURATOR = "com.vaadin.flow.component.page.AppShellConfigurator"
 internal const val VAADIN_ID = "com.vaadin.flow.component.template.Id"
 internal const val VAADIN_TAG = "com.vaadin.flow.component.Tag"
-
-internal fun hasVaadinFlow(project: Project): Boolean = hasLibraryClass(project, VAADIN_ROUTE)
-
-internal fun hasVaadinFlow(module: Module): Boolean = hasLibraryClass(module, VAADIN_ROUTE)
 
 internal fun findVaadinRoutes(project: Project, scope: GlobalSearchScope): Collection<VaadinRoute> {
     val vaadinRouteClass =

--- a/src/main/kotlin/com/vaadin/plugin/endpoints/VaadinUrlResolver.kt
+++ b/src/main/kotlin/com/vaadin/plugin/endpoints/VaadinUrlResolver.kt
@@ -14,11 +14,12 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PartiallyKnownString
 import com.intellij.psi.util.SplitEscaper
 import com.vaadin.plugin.utils.VaadinIcons
+import com.vaadin.plugin.utils.hasVaadin
 import javax.swing.Icon
 
 internal class VaadinUrlResolverFactory : UrlResolverFactory {
     override fun forProject(project: Project): UrlResolver? {
-        return if (hasVaadinFlow(project)) VaadinUrlResolver(project) else null
+        return if (hasVaadin(project)) VaadinUrlResolver(project) else null
     }
 }
 
@@ -51,7 +52,7 @@ private fun getAllModuleVariants(project: Project): Sequence<VaadinUrlTargetInfo
 }
 
 private fun getVariants(module: Module): Sequence<VaadinRoute> {
-    if (!hasVaadinFlow(module)) return emptySequence()
+    if (!hasVaadin(module)) return emptySequence()
 
     return sequenceWithCache(ModuleCacheValueHolder(module), VAADIN_ROUTES_SEARCH)
 }

--- a/src/main/kotlin/com/vaadin/plugin/utils/VaadinProjectUtil.kt
+++ b/src/main/kotlin/com/vaadin/plugin/utils/VaadinProjectUtil.kt
@@ -1,11 +1,9 @@
 package com.vaadin.plugin.utils
 
+import com.intellij.java.library.JavaLibraryUtil.hasLibraryClass
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.observable.properties.GraphProperty
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ModuleRootManager
-import com.intellij.openapi.roots.libraries.Library
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -18,13 +16,13 @@ import java.nio.file.Path
 import java.util.*
 import java.util.zip.ZipFile
 
+internal const val VAADIN_SERVICE = "com.vaadin.flow.server.VaadinService"
+
 class VaadinProjectUtil {
 
     companion object {
 
         private val LOG: Logger = Logger.getInstance(VaadinProjectUtil::class.java)
-
-        private const val VAADIN_LIB_PREFIX = "com.vaadin:"
 
         val PROJECT_DOWNLOADED_PROP_KEY = Key<GraphProperty<Boolean>>("vaadin_project_downloaded")
 
@@ -74,20 +72,9 @@ class VaadinProjectUtil {
                 return null
             }
         }
-
-        fun isVaadinProject(project: Project): Boolean {
-            return ModuleManager.getInstance(project).modules.any { isVaadinModule(it) }
-        }
-
-        fun isVaadinModule(module: com.intellij.openapi.module.Module): Boolean {
-            var hasVaadin = false
-            ModuleRootManager.getInstance(module).orderEntries().forEachLibrary { library: Library ->
-                if (library.name?.contains(VAADIN_LIB_PREFIX) == true) {
-                    hasVaadin = true
-                }
-                true
-            }
-            return hasVaadin
-        }
     }
 }
+
+internal fun hasVaadin(project: Project): Boolean = hasLibraryClass(project, VAADIN_SERVICE)
+
+internal fun hasVaadin(module: com.intellij.openapi.module.Module): Boolean = hasLibraryClass(module, VAADIN_SERVICE)


### PR DESCRIPTION
Use `hasLibraryClass` to detect Vaadin. Should be more reliable and faster than previous solution.

Fixes #166 
