### PR TITLE
fix: hotswap only for java run configurations

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/actions/DebugUsingHotSwapAgentAction.kt
+++ b/src/main/kotlin/com/vaadin/plugin/actions/DebugUsingHotSwapAgentAction.kt
@@ -3,12 +3,29 @@ package com.vaadin.plugin.actions
 import com.intellij.execution.Executor
 import com.intellij.execution.ExecutorRegistry
 import com.intellij.execution.dashboard.actions.ExecutorAction
+import com.intellij.execution.dashboard.tree.RunConfigurationNode
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.PlatformCoreDataKeys
 import com.vaadin.plugin.hotswapagent.HotswapAgentExecutor
 import com.vaadin.plugin.utils.VaadinIcons
+import org.jetbrains.idea.maven.execution.MavenRunConfiguration
+import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration
 
 class DebugUsingHotSwapAgentAction : ExecutorAction() {
     override fun update(event: AnActionEvent, isRunning: Boolean) {
+        if (event.dataContext.getData(PlatformCoreDataKeys.SELECTED_ITEM) != null) {
+            if (event.dataContext.getData(PlatformCoreDataKeys.SELECTED_ITEM) is RunConfigurationNode) {
+                val runConfiguration =
+                    (event.dataContext.getData(PlatformCoreDataKeys.SELECTED_ITEM) as RunConfigurationNode)
+                        .configurationSettings
+                        .configuration
+                if (runConfiguration is MavenRunConfiguration || runConfiguration is GradleRunConfiguration) {
+                    event.presentation.isVisible = false
+                    event.presentation.text = null
+                    return
+                }
+            }
+        }
         if (isRunning) {
             event.presentation.text = "Rerun using HotSwapAgent"
             event.presentation.icon = VaadinIcons.RERUN_HOTSWAP

--- a/src/main/kotlin/com/vaadin/plugin/hotswapagent/HotswapAgentExecutor.kt
+++ b/src/main/kotlin/com/vaadin/plugin/hotswapagent/HotswapAgentExecutor.kt
@@ -1,8 +1,13 @@
 package com.vaadin.plugin.hotswapagent
 
+import com.intellij.execution.JavaRunConfigurationBase
+import com.intellij.execution.RunManager
 import com.intellij.execution.executors.DefaultDebugExecutor
+import com.intellij.openapi.project.Project
 import com.vaadin.plugin.utils.VaadinIcons
 import javax.swing.Icon
+import org.jetbrains.idea.maven.execution.MavenRunConfiguration
+import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration
 
 class HotswapAgentExecutor : DefaultDebugExecutor() {
 
@@ -48,5 +53,11 @@ class HotswapAgentExecutor : DefaultDebugExecutor() {
 
     override fun getDisabledIcon(): Icon {
         return super.getDisabledIcon()
+    }
+
+    override fun isApplicable(project: Project): Boolean {
+        val selectedConfiguration = RunManager.getInstance(project).selectedConfiguration?.configuration
+        return selectedConfiguration is JavaRunConfigurationBase &&
+            (selectedConfiguration !is MavenRunConfiguration || selectedConfiguration !is GradleRunConfiguration)
     }
 }


### PR DESCRIPTION
## Description

Filtering HotSwap option launcher for non Java Run configurations (maven/gradle). This PR fixes the issue for the standard launch toolbar and the services window. 
We would fix the issue for other windows (Maven/Gradle) in a subsequent PR because it requires further investigation. 

Check the video for expected result 

Fixes #144 

https://github.com/user-attachments/assets/d2a1f7aa-1359-4cf6-bf7b-ea6b61ba0c6f


## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
