### PR TITLE
fix: filtering HotSwap option in Run/Debug toolbar for non Java run configurations

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/hotswapagent/HotswapAgentExecutor.kt
+++ b/src/main/kotlin/com/vaadin/plugin/hotswapagent/HotswapAgentExecutor.kt
@@ -1,8 +1,13 @@
 package com.vaadin.plugin.hotswapagent
 
+import com.intellij.execution.JavaRunConfigurationBase
+import com.intellij.execution.RunManager
 import com.intellij.execution.executors.DefaultDebugExecutor
+import com.intellij.openapi.project.Project
 import com.vaadin.plugin.utils.VaadinIcons
 import javax.swing.Icon
+import org.jetbrains.idea.maven.execution.MavenRunConfiguration
+import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration
 
 class HotswapAgentExecutor : DefaultDebugExecutor() {
 
@@ -48,5 +53,11 @@ class HotswapAgentExecutor : DefaultDebugExecutor() {
 
     override fun getDisabledIcon(): Icon {
         return super.getDisabledIcon()
+    }
+
+    override fun isApplicable(project: Project): Boolean {
+        val selectedConfiguration = RunManager.getInstance(project).selectedConfiguration?.configuration
+        return selectedConfiguration is JavaRunConfigurationBase &&
+            (selectedConfiguration !is MavenRunConfiguration || selectedConfiguration !is GradleRunConfiguration)
     }
 }


### PR DESCRIPTION
## Description

Disable Hotswap option when a non java run configuration (Maven/Gradle) is selected in the Run/debug toolbar.

Fixes #144 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
