### PR TITLE
fix: User IntelliJ API to distinguish users for statistics

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/utils/AmpliUtil.kt
+++ b/src/main/kotlin/com/vaadin/plugin/utils/AmpliUtil.kt
@@ -5,12 +5,13 @@ import com.amplitude.ampli.EventOptions
 import com.amplitude.ampli.LoadOptions
 import com.amplitude.ampli.ProjectCreated
 import com.amplitude.ampli.ampli
+import com.intellij.internal.statistic.DeviceIdManager
+import com.intellij.internal.statistic.DeviceIdManager.DeviceIdToken
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.util.io.DigestUtil
 import com.vaadin.plugin.copilot.CopilotPluginUtil
 import com.vaadin.plugin.ui.settings.VaadinSettings
 import com.vaadin.pro.licensechecker.LocalProKey
-import com.vaadin.pro.licensechecker.MachineId
 import com.vaadin.pro.licensechecker.ProKey
 import java.nio.charset.Charset
 
@@ -35,7 +36,7 @@ private fun getUserId(): String? {
             if (proKey != null) {
                 "pro-${DigestUtil.sha256Hex(proKey.proKey.toByteArray(Charset.defaultCharset()))}"
             } else {
-                MachineId.get()
+                DeviceIdManager.getOrGenerateId(object : DeviceIdToken {}, "vaadin-plugin")
             }
         ampli.load(LoadOptions(Ampli.Environment.IDEPLUGINS))
         ampli.identify(userId, eventOptions)


### PR DESCRIPTION
Fixes: #247 by removing MachineId.get() call. 

Using internal API, verification required.