### PR TITLE
fix: Use DynamicPluginListener to create and remove .copilot-plugin

### DIFF
--- a/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotDynamicPluginListener.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotDynamicPluginListener.kt
@@ -19,5 +19,4 @@ class CopilotDynamicPluginListener(private val project: Project) : DynamicPlugin
         CopilotPluginUtil.saveDotFile(project)
         LOG.debug("Plugin loaded, .copilot-plugin created")
     }
-
 }

--- a/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotDynamicPluginListener.kt
+++ b/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotDynamicPluginListener.kt
@@ -1,0 +1,23 @@
+package com.vaadin.plugin.copilot.listeners
+
+import com.intellij.ide.plugins.DynamicPluginListener
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.vaadin.plugin.copilot.CopilotPluginUtil
+
+class CopilotDynamicPluginListener(private val project: Project) : DynamicPluginListener {
+
+    private val LOG: Logger = Logger.getInstance(CopilotDynamicPluginListener::class.java)
+
+    override fun beforePluginUnload(pluginDescriptor: IdeaPluginDescriptor, isUpdate: Boolean) {
+        CopilotPluginUtil.removeDotFile(project)
+        LOG.debug("Plugin is going to be unloaded, .copilot-plugin removed")
+    }
+
+    override fun pluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
+        CopilotPluginUtil.saveDotFile(project)
+        LOG.debug("Plugin loaded, .copilot-plugin created")
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -126,6 +126,9 @@
         <listener
             class="com.vaadin.plugin.listeners.ConfigurationCheckVaadinProjectListener"
             topic="com.vaadin.plugin.listeners.VaadinProjectListener" />
+        <listener
+                class="com.vaadin.plugin.copilot.listeners.CopilotDynamicPluginListener"
+                topic="com.intellij.ide.plugins.DynamicPluginListener"/>
     </projectListeners>
 
 </idea-plugin>


### PR DESCRIPTION
This PR fixes issue when plugin is Enabled and Disabled leaving `.copilot-plugin` not removed or created.

Fixes: #296 
Fixes: #295 