### PR TITLE
Restart service and reload maven module endpoints

### DIFF
--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
@@ -100,7 +100,8 @@ class CopilotPluginUtil {
                 HANDLERS.COMPILE_FILES.command -> return CompileFilesHandler(project, data)
                 HANDLERS.RESTART_APPLICATION.command -> return RestartApplicationHandler(project)
                 HANDLERS.RESTART_SERVICE.command -> return RestartServiceHandler(project, data["serviceName"] as String)
-                HANDLERS.RELOAD_MAVEN_MODULE.command -> return ReloadMavenModuleHandler(project, data["moduleName"] as String)
+                HANDLERS.RELOAD_MAVEN_MODULE.command ->
+                    return ReloadMavenModuleHandler(project, data["moduleName"] as String)
                 else -> {
                     LOG.warn("Command $command not supported by plugin")
                     return object : Handler {

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
@@ -22,18 +22,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.findDirectory
 import com.intellij.openapi.vfs.findFile
 import com.intellij.openapi.vfs.findOrCreateDirectory
-import com.vaadin.plugin.copilot.handler.CompileFilesHandler
-import com.vaadin.plugin.copilot.handler.DeleteFileHandler
-import com.vaadin.plugin.copilot.handler.GetModulePathsHandler
-import com.vaadin.plugin.copilot.handler.Handler
-import com.vaadin.plugin.copilot.handler.HandlerResponse
-import com.vaadin.plugin.copilot.handler.RedoHandler
-import com.vaadin.plugin.copilot.handler.RefreshHandler
-import com.vaadin.plugin.copilot.handler.RestartApplicationHandler
-import com.vaadin.plugin.copilot.handler.ShowInIdeHandler
-import com.vaadin.plugin.copilot.handler.UndoHandler
-import com.vaadin.plugin.copilot.handler.WriteBase64FileHandler
-import com.vaadin.plugin.copilot.handler.WriteFileHandler
+import com.vaadin.plugin.copilot.handler.*
 import com.vaadin.plugin.utils.VaadinIcons
 import io.netty.handler.codec.http.HttpResponseStatus
 import java.io.BufferedWriter
@@ -79,6 +68,8 @@ class CopilotPluginUtil {
             GET_MODULE_PATHS("getModulePaths"),
             COMPILE_FILES("compileFiles"),
             RESTART_APPLICATION("restartApplication"),
+            RESTART_SERVICE("restartService"),
+            RELOAD_MAVEN_MODULE("reloadMavenModule"),
         }
 
         private val pluginVersion = PluginManagerCore.getPlugin(PluginId.getId("com.vaadin.intellij-plugin"))?.version
@@ -108,6 +99,8 @@ class CopilotPluginUtil {
                 HANDLERS.GET_MODULE_PATHS.command -> return GetModulePathsHandler(project)
                 HANDLERS.COMPILE_FILES.command -> return CompileFilesHandler(project, data)
                 HANDLERS.RESTART_APPLICATION.command -> return RestartApplicationHandler(project)
+                HANDLERS.RESTART_SERVICE.command -> return RestartServiceHandler(project, data["serviceName"] as String)
+                HANDLERS.RELOAD_MAVEN_MODULE.command -> return ReloadMavenModuleHandler(project, data["moduleName"] as String)
                 else -> {
                     LOG.warn("Command $command not supported by plugin")
                     return object : Handler {

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/handler/ReloadMavenModuleHandler.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/handler/ReloadMavenModuleHandler.kt
@@ -1,0 +1,25 @@
+package com.vaadin.plugin.copilot.handler
+
+import com.intellij.execution.runners.ExecutionUtil
+import com.intellij.execution.ui.RunContentManager
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.project.Project
+import org.jetbrains.idea.maven.project.MavenProjectsManager
+
+class ReloadMavenModuleHandler(project: Project, moduleName: String) : AbstractHandler(project) {
+
+    private val moduleName: String = moduleName as String
+
+    override fun run(): HandlerResponse {
+        runInEdt {
+            val mavenProjectsManager = MavenProjectsManager.getInstance(project)
+            mavenProjectsManager.projects.firstOrNull { it.displayName == moduleName }?.let { mavenProject ->
+                LOG.debug("Reloading ${mavenProject.displayName} (${project.name})")
+                mavenProjectsManager.scheduleForceUpdateMavenProject(mavenProject)
+                return@runInEdt
+            }
+            LOG.debug("Reloading of $moduleName failed - content not found")
+        }
+        return RESPONSE_OK
+    }
+}

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/handler/ReloadMavenModuleHandler.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/handler/ReloadMavenModuleHandler.kt
@@ -1,7 +1,5 @@
 package com.vaadin.plugin.copilot.handler
 
-import com.intellij.execution.runners.ExecutionUtil
-import com.intellij.execution.ui.RunContentManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.Project
 import org.jetbrains.idea.maven.project.MavenProjectsManager
@@ -13,11 +11,13 @@ class ReloadMavenModuleHandler(project: Project, moduleName: String) : AbstractH
     override fun run(): HandlerResponse {
         runInEdt {
             val mavenProjectsManager = MavenProjectsManager.getInstance(project)
-            mavenProjectsManager.projects.firstOrNull { it.displayName == moduleName }?.let { mavenProject ->
-                LOG.debug("Reloading ${mavenProject.displayName} (${project.name})")
-                mavenProjectsManager.scheduleForceUpdateMavenProject(mavenProject)
-                return@runInEdt
-            }
+            mavenProjectsManager.projects
+                .firstOrNull { it.displayName == moduleName }
+                ?.let { mavenProject ->
+                    LOG.debug("Reloading ${mavenProject.displayName} (${project.name})")
+                    mavenProjectsManager.scheduleForceUpdateMavenProject(mavenProject)
+                    return@runInEdt
+                }
             LOG.debug("Reloading of $moduleName failed - content not found")
         }
         return RESPONSE_OK

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/handler/RestartServiceHandler.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/handler/RestartServiceHandler.kt
@@ -1,0 +1,26 @@
+package com.vaadin.plugin.copilot.handler
+
+import com.intellij.execution.runners.ExecutionUtil
+import com.intellij.execution.ui.RunContentManager
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.project.Project
+
+class RestartServiceHandler(project: Project, serviceName: String) : AbstractHandler(project) {
+
+    private val serviceName: String = serviceName as String
+
+    override fun run(): HandlerResponse {
+        runInEdt {
+            val contentManager = RunContentManager.getInstance(project)
+            for (descriptor in contentManager.allDescriptors) {
+                if (descriptor.displayName == serviceName) {
+                    LOG.debug("Restarting ${descriptor.displayName} (${project.name})")
+                    ExecutionUtil.restart(descriptor)
+                    break
+                }
+            }
+            LOG.debug("Restart of ${project.name} failed - content not found")
+        }
+        return RESPONSE_OK
+    }
+}


### PR DESCRIPTION
## Description

This targeted for the prototype and yet no use for current copilot, but I think it won't harm to have it in production so we can use it easily in the prototype. 

So the new services are
- Reload Maven module (by module name)
- Restart service (by service name)

The prototype would ask the user to setup the module and service names. I've been thinking about how to discover this from the application to include it in current Copilot. But is out of scope of this PR. 

Eventually the restartService endpoint could replace the current restartApplication in current copilot as we have now an issue identifying the application to restart.  