### PR TITLE
feat: Allows navigating from Java to TypeScript

### DIFF
--- a/plugin/src/main/kotlin/com/vaadin/plugin/psi/HillaReferenceSearcher.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/psi/HillaReferenceSearcher.kt
@@ -20,6 +20,8 @@ class HillaReferenceSearcher : QueryExecutorBase<PsiReference, MethodReferencesS
 
     private val tsFileType = FileTypeManager.getInstance().getFileTypeByExtension("ts")
     private val tsxFileType = FileTypeManager.getInstance().getFileTypeByExtension("tsx")
+    private val jsFileType = FileTypeManager.getInstance().getFileTypeByExtension("js")
+    private val jsxFileType = FileTypeManager.getInstance().getFileTypeByExtension("jsx")
 
     override fun processQuery(
         queryParameters: MethodReferencesSearch.SearchParameters,
@@ -35,7 +37,8 @@ class HillaReferenceSearcher : QueryExecutorBase<PsiReference, MethodReferencesS
             val searchHelper = PsiSearchHelper.getInstance(queryParameters.project)
             val scope = GlobalSearchScope.projectScope(queryParameters.project)
 
-            val filteredScope = GlobalSearchScope.getScopeRestrictedByFileTypes(scope, tsFileType, tsxFileType)
+            val filteredScope =
+                GlobalSearchScope.getScopeRestrictedByFileTypes(scope, tsFileType, tsxFileType, jsFileType, jsxFileType)
             searchHelper.processElementsWithWord(
                 { psiElement, offset ->
                     if (psiElement.elementType == JSElementTypes.REFERENCE_EXPRESSION) {

--- a/plugin/src/main/kotlin/com/vaadin/plugin/psi/HillaReferenceSearcher.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/psi/HillaReferenceSearcher.kt
@@ -1,9 +1,9 @@
 package com.vaadin.plugin.psi
 
 import com.intellij.lang.javascript.JSElementTypes
-import com.intellij.lang.javascript.TypeScriptJSXFileType
 import com.intellij.openapi.application.QueryExecutorBase
 import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
@@ -18,6 +18,8 @@ import com.vaadin.plugin.endpoints.HILLA_BROWSER_CALLABLE
 
 class HillaReferenceSearcher : QueryExecutorBase<PsiReference, MethodReferencesSearch.SearchParameters>() {
 
+    private val typeScriptFileType = FileTypeManager.getInstance().getFileTypeByExtension("tsx")
+
     override fun processQuery(
         queryParameters: MethodReferencesSearch.SearchParameters,
         consumer: Processor<in PsiReference>
@@ -31,7 +33,6 @@ class HillaReferenceSearcher : QueryExecutorBase<PsiReference, MethodReferencesS
 
             val searchHelper = PsiSearchHelper.getInstance(queryParameters.project)
             val scope = GlobalSearchScope.projectScope(queryParameters.project)
-            val typeScriptFileType = TypeScriptJSXFileType.INSTANCE
 
             val filteredScope = GlobalSearchScope.getScopeRestrictedByFileTypes(scope, typeScriptFileType)
             searchHelper.processElementsWithWord(

--- a/plugin/src/main/kotlin/com/vaadin/plugin/psi/HillaReferenceSearcher.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/psi/HillaReferenceSearcher.kt
@@ -18,7 +18,8 @@ import com.vaadin.plugin.endpoints.HILLA_BROWSER_CALLABLE
 
 class HillaReferenceSearcher : QueryExecutorBase<PsiReference, MethodReferencesSearch.SearchParameters>() {
 
-    private val typeScriptFileType = FileTypeManager.getInstance().getFileTypeByExtension("tsx")
+    private val tsFileType = FileTypeManager.getInstance().getFileTypeByExtension("ts")
+    private val tsxFileType = FileTypeManager.getInstance().getFileTypeByExtension("tsx")
 
     override fun processQuery(
         queryParameters: MethodReferencesSearch.SearchParameters,
@@ -34,7 +35,7 @@ class HillaReferenceSearcher : QueryExecutorBase<PsiReference, MethodReferencesS
             val searchHelper = PsiSearchHelper.getInstance(queryParameters.project)
             val scope = GlobalSearchScope.projectScope(queryParameters.project)
 
-            val filteredScope = GlobalSearchScope.getScopeRestrictedByFileTypes(scope, typeScriptFileType)
+            val filteredScope = GlobalSearchScope.getScopeRestrictedByFileTypes(scope, tsFileType, tsxFileType)
             searchHelper.processElementsWithWord(
                 { psiElement, offset ->
                     if (psiElement.elementType == JSElementTypes.REFERENCE_EXPRESSION) {

--- a/plugin/src/main/kotlin/com/vaadin/plugin/psi/HillaReferenceSearcher.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/psi/HillaReferenceSearcher.kt
@@ -1,0 +1,47 @@
+package com.vaadin.plugin.psi
+
+import com.intellij.lang.javascript.JSElementTypes
+import com.intellij.lang.javascript.TypeScriptJSXFileType
+import com.intellij.openapi.application.QueryExecutorBase
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PsiSearchHelper
+import com.intellij.psi.search.UsageSearchContext
+import com.intellij.psi.search.searches.MethodReferencesSearch
+import com.intellij.psi.util.elementType
+import com.intellij.util.Processor
+
+class HillaReferenceSearcher : QueryExecutorBase<PsiReference, MethodReferencesSearch.SearchParameters>() {
+
+    override fun processQuery(
+        queryParameters: MethodReferencesSearch.SearchParameters,
+        consumer: Processor<in PsiReference>
+    ) {
+        val element = queryParameters.method
+
+        val searchHelper = PsiSearchHelper.getInstance(queryParameters.project)
+        val scope = GlobalSearchScope.projectScope(queryParameters.project)
+        val typeScriptFileType = TypeScriptJSXFileType.INSTANCE
+
+        val filteredScope = GlobalSearchScope.getScopeRestrictedByFileTypes(scope, typeScriptFileType)
+        searchHelper.processElementsWithWord(
+            { psiElement, offset ->
+                if (psiElement.elementType == JSElementTypes.REFERENCE_EXPRESSION) {
+                    val range = TextRange(offset, offset + element.name.length)
+                    val reference =
+                        object : PsiReferenceBase<PsiElement>(psiElement, range) {
+                            override fun resolve(): PsiElement = psiElement
+                        }
+                    consumer.process(reference)
+                }
+                true // return false to stop the search early
+            },
+            filteredScope,
+            element.name,
+            UsageSearchContext.IN_CODE,
+            true)
+    }
+}

--- a/plugin/src/main/resources/META-INF/vaadin-with-javascript.xml
+++ b/plugin/src/main/resources/META-INF/vaadin-with-javascript.xml
@@ -6,6 +6,8 @@
                                      referenceClass="com.vaadin.plugin.symbols.HillaSymbolReference"
                                      targetClass="com.vaadin.plugin.symbols.HillaSymbol"
                                      implementationClass="com.vaadin.plugin.symbols.HillaSymbolReferenceProvider"/>
+
+        <methodReferencesSearch implementation="com.vaadin.plugin.psi.HillaReferenceSearcher"/>
     </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
Allows navigating from Hilla method reference to TypeScript.

<img width="810" alt="image" src="https://github.com/user-attachments/assets/a8d89ccc-f4b6-439b-b76e-0c38023a360f" />


nit: there is a bug somewhere because above method you see 4 usages and in popup there are 2...