### PR TITLE
ref: Manage dotfile with separate service not to cause exceptions

### DIFF
--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
@@ -4,8 +4,6 @@ import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.module.Module
@@ -14,20 +12,28 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.DumbModeTask
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.roots.CompilerModuleExtension
 import com.intellij.openapi.roots.ModuleRootManager
-import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.findDirectory
-import com.intellij.openapi.vfs.findFile
-import com.intellij.openapi.vfs.findOrCreateDirectory
-import com.vaadin.plugin.copilot.handler.*
+import com.vaadin.plugin.copilot.handler.CompileFilesHandler
+import com.vaadin.plugin.copilot.handler.DeleteFileHandler
+import com.vaadin.plugin.copilot.handler.GetModulePathsHandler
+import com.vaadin.plugin.copilot.handler.Handler
+import com.vaadin.plugin.copilot.handler.HandlerResponse
+import com.vaadin.plugin.copilot.handler.RedoHandler
+import com.vaadin.plugin.copilot.handler.RefreshHandler
+import com.vaadin.plugin.copilot.handler.ReloadMavenModuleHandler
+import com.vaadin.plugin.copilot.handler.RestartApplicationHandler
+import com.vaadin.plugin.copilot.handler.ShowInIdeHandler
+import com.vaadin.plugin.copilot.handler.UndoHandler
+import com.vaadin.plugin.copilot.handler.WriteBase64FileHandler
+import com.vaadin.plugin.copilot.handler.WriteFileHandler
+import com.vaadin.plugin.copilot.service.CopilotDotfileService
 import com.vaadin.plugin.utils.VaadinIcons
 import io.netty.handler.codec.http.HttpResponseStatus
 import java.io.BufferedWriter
 import java.io.IOException
 import java.io.StringWriter
+import java.nio.file.Files
 import java.util.Properties
 import org.jetbrains.jps.model.java.JavaResourceRootType
 import org.jetbrains.jps.model.java.JavaSourceRootType
@@ -50,10 +56,6 @@ class CopilotPluginUtil {
     companion object {
 
         private val LOG: Logger = Logger.getInstance(CopilotPluginUtil::class.java)
-
-        private const val DOTFILE = ".copilot-plugin"
-
-        private const val IDEA_DIR = ".idea"
 
         private const val NORMALIZED_LINE_SEPARATOR = "\n"
 
@@ -100,6 +102,7 @@ class CopilotPluginUtil {
                 HANDLERS.RESTART_APPLICATION.command -> return RestartApplicationHandler(project, data)
                 HANDLERS.RELOAD_MAVEN_MODULE.command ->
                     return ReloadMavenModuleHandler(project, data["moduleName"] as String)
+
                 else -> {
                     LOG.warn("Command $command not supported by plugin")
                     return object : Handler {
@@ -122,83 +125,30 @@ class CopilotPluginUtil {
         }
 
         private fun saveDotFileInternal(project: Project) {
-            runInEdt {
-                WriteAction.run<Throwable> {
-                    val dotFileDirectory = getDotFileDirectory(project, true)
-                    if (dotFileDirectory != null) {
-                        val props = Properties()
-                        props.setProperty("endpoint", RestUtil.getEndpoint())
-                        props.setProperty("ide", "intellij")
-                        props.setProperty("version", pluginVersion)
-                        props.setProperty("supportedActions", HANDLERS.entries.joinToString(",") { a -> a.command })
+            val dotfileService = project.getService(CopilotDotfileService::class.java)
+            val dotFileDirectory = dotfileService.getDotfileDirectory()
+            if (dotFileDirectory != null && Files.exists(dotFileDirectory)) {
+                val props = Properties()
+                props.setProperty("endpoint", RestUtil.getEndpoint())
+                props.setProperty("ide", "intellij")
+                props.setProperty("version", pluginVersion)
+                props.setProperty("supportedActions", HANDLERS.entries.joinToString(",") { a -> a.command })
 
-                        val stringWriter = StringWriter()
-                        val bufferedWriter =
-                            object : BufferedWriter(stringWriter) {
-                                override fun newLine() {
-                                    write(NORMALIZED_LINE_SEPARATOR)
-                                }
-                            }
-                        props.store(bufferedWriter, "Vaadin Copilot Integration Runtime Properties")
-                        val dotFile = dotFileDirectory.findFile(DOTFILE)
-                        dotFile?.let {
-                            try {
-                                it.delete(this)
-                            } catch (e: IOException) {
-                                LOG.error("Failed to delete $DOTFILE: ${e.message}")
-                            }
-                        }
-                        val newFile =
-                            try {
-                                dotFileDirectory.createChildData(this, DOTFILE)
-                            } catch (e: IOException) {
-                                LOG.error("Failed to create $DOTFILE: ${e.message}")
-                                return@run
-                            }
-
-                        try {
-                            VfsUtil.saveText(newFile, stringWriter.toString())
-                        } catch (e: IOException) {
-                            LOG.error("Failed to write to $DOTFILE: ${e.message}")
-                        }
-                        LOG.info("$newFile created")
-                    }
-                }
-            }
-        }
-
-        fun removeDotFile(project: Project) {
-            runInEdt {
-                WriteAction.run<Throwable> {
-                    val dotFile = getDotFileDirectory(project, false)?.findFile(DOTFILE)
-                    dotFile?.let {
-                        try {
-                            it.delete(this)
-                            LOG.info("$it removed")
-                        } catch (e: IOException) {
-                            LOG.error("Failed to delete $DOTFILE: ${e.message}")
+                val stringWriter = StringWriter()
+                val bufferedWriter =
+                    object : BufferedWriter(stringWriter) {
+                        override fun newLine() {
+                            write(NORMALIZED_LINE_SEPARATOR)
                         }
                     }
+                props.store(bufferedWriter, "Vaadin Copilot Integration Runtime Properties")
+                try {
+                    dotfileService.removeDotfile()
+                    dotfileService.createDotfile(stringWriter.toString())
+                } catch (e: IOException) {
+                    LOG.error("Failed to save dotfile: ${e.message}")
                 }
             }
-        }
-
-        private fun getDotFileDirectory(project: Project, create: Boolean): VirtualFile? {
-            val projectDir = project.guessProjectDir()
-            if (projectDir == null) {
-                LOG.error("Cannot guess project directory")
-                return null
-            }
-            LOG.info("Project directory: $projectDir")
-            return if (create) projectDir.findOrCreateDirectory(IDEA_DIR) else projectDir.findDirectory(IDEA_DIR)
-        }
-
-        fun getDotFile(project: Project): VirtualFile? {
-            return getDotFileDirectory(project, false)?.findFile(DOTFILE)
-        }
-
-        fun isActive(project: Project): Boolean {
-            return getDotFile(project)?.exists() ?: false
         }
 
         /**

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/DefaultProgramPatcher.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/DefaultProgramPatcher.kt
@@ -5,6 +5,7 @@ import com.intellij.execution.configurations.JavaParameters
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.configurations.RunProfile
 import com.intellij.execution.runners.JavaProgramPatcher
+import com.vaadin.plugin.copilot.service.CopilotDotfileService
 
 class DefaultProgramPatcher : JavaProgramPatcher() {
 
@@ -16,8 +17,8 @@ class DefaultProgramPatcher : JavaProgramPatcher() {
         val paramsList = javaParameters.vmParametersList
 
         if (runProfile is RunConfiguration) {
-            CopilotPluginUtil.getDotFile(runProfile.project)?.let {
-                paramsList.add("-Dvaadin.copilot.pluginDotFilePath=${it.path}")
+            runProfile.project.getService(CopilotDotfileService::class.java).getDotfile()?.let {
+                paramsList.add("-Dvaadin.copilot.pluginDotFilePath=${it}")
             }
         }
     }

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotDynamicPluginListener.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotDynamicPluginListener.kt
@@ -5,13 +5,14 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.vaadin.plugin.copilot.CopilotPluginUtil
+import com.vaadin.plugin.copilot.service.CopilotDotfileService
 
 class CopilotDynamicPluginListener(private val project: Project) : DynamicPluginListener {
 
     private val LOG: Logger = Logger.getInstance(CopilotDynamicPluginListener::class.java)
 
     override fun beforePluginUnload(pluginDescriptor: IdeaPluginDescriptor, isUpdate: Boolean) {
-        CopilotPluginUtil.removeDotFile(project)
+        project.getService(CopilotDotfileService::class.java).removeDotfile()
         LOG.debug("Plugin is going to be unloaded, .copilot-plugin removed")
     }
 

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotVaadinProjectListener.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotVaadinProjectListener.kt
@@ -2,37 +2,16 @@ package com.vaadin.plugin.copilot.listeners
 
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.ProjectManager
-import com.intellij.openapi.project.ProjectManagerListener
-import com.vaadin.plugin.copilot.CopilotPluginUtil
 import com.vaadin.plugin.copilot.CopilotPluginUtil.Companion.saveDotFile
 import com.vaadin.plugin.listeners.VaadinProjectListener
 import com.vaadin.plugin.ui.VaadinStatusBarWidget
 
 class CopilotVaadinProjectListener : VaadinProjectListener {
 
-    private var listenerRegistered = false
-
     override fun vaadinProjectDetected(project: Project) {
         if (!project.isDisposed) {
             saveDotFile(project)
-            removeDotFileOnExit(project)
             DumbService.getInstance(project).smartInvokeLater { VaadinStatusBarWidget.update(project) }
-        }
-    }
-
-    private fun removeDotFileOnExit(project: Project) {
-        if (!listenerRegistered) {
-            listenerRegistered = true
-            ProjectManager.getInstance()
-                .addProjectManagerListener(
-                    project,
-                    object : ProjectManagerListener {
-                        override fun projectClosing(project: Project) {
-                            CopilotPluginUtil.removeDotFile(project)
-                        }
-                    },
-                )
         }
     }
 }

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/service/CopilotDotfileService.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/service/CopilotDotfileService.kt
@@ -1,0 +1,17 @@
+package com.vaadin.plugin.copilot.service
+
+import java.io.IOException
+import java.nio.file.Path
+
+interface CopilotDotfileService {
+
+    fun isActive(): Boolean
+
+    @Throws(IOException::class) fun removeDotfile()
+
+    @Throws(IOException::class) fun createDotfile(content: String)
+
+    fun getDotfileDirectory(): Path?
+
+    fun getDotfile(): Path?
+}

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/service/CopilotDotfileServiceImpl.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/service/CopilotDotfileServiceImpl.kt
@@ -1,0 +1,90 @@
+package com.vaadin.plugin.copilot.service
+
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.ProjectManagerListener
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class CopilotDotfileServiceImpl(private val project: Project) : CopilotDotfileService {
+
+    private val DOTFILE = ".copilot-plugin"
+    private val IDEA_DIR = ".idea"
+
+    private val _fileExists = MutableStateFlow(false)
+    private val fileExists: StateFlow<Boolean> = _fileExists.asStateFlow()
+
+    init {
+        val connection = project.messageBus.connect()
+        connection.subscribe(
+            VirtualFileManager.VFS_CHANGES,
+            object : BulkFileListener {
+                override fun after(events: List<VFileEvent>) {
+                    for (event in events) {
+                        when (event) {
+                            is VFileCreateEvent ->
+                                if (Path.of(event.path).equals(getDotfile())) _fileExists.value = true
+                            is VFileDeleteEvent ->
+                                if (Path.of(event.path).equals(getDotfile())) _fileExists.value = false
+                        }
+                    }
+                }
+            })
+
+        // Initial state
+        _fileExists.value = getDotfile()?.let { Files.exists(it) } ?: false
+
+        ProjectManager.getInstance()
+            .addProjectManagerListener(
+                project,
+                object : ProjectManagerListener {
+                    override fun projectClosing(project: Project) {
+                        removeDotfile()
+                    }
+                },
+            )
+    }
+
+    override fun isActive(): Boolean {
+        return fileExists.value
+    }
+
+    override fun getDotfileDirectory(): Path? {
+        return project.guessProjectDir()?.toNioPath()?.resolve(IDEA_DIR)
+    }
+
+    override fun getDotfile(): Path? {
+        return getDotfileDirectory()?.resolve(DOTFILE)
+    }
+
+    @Throws(IOException::class)
+    override fun removeDotfile() {
+        runInEdt { WriteAction.run<Throwable> { getDotfile()?.let { VfsUtil.findFile(it, false)?.delete(this) } } }
+    }
+
+    @Throws(IOException::class)
+    override fun createDotfile(content: String) {
+        runInEdt {
+            WriteAction.run<Throwable> {
+                val dotfileDirectory = getDotfileDirectory() ?: throw IOException("Could not find the .idea directory")
+                val vfsDotfileDirectory =
+                    VfsUtil.findFile(dotfileDirectory, true) ?: throw IOException("Could not find the .idea directory")
+                val dotfile = vfsDotfileDirectory.createChildData(this, DOTFILE)
+                VfsUtil.saveText(dotfile, content)
+            }
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/vaadin/plugin/ui/VaadinStatusBarInfoPopupPanel.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/ui/VaadinStatusBarInfoPopupPanel.kt
@@ -9,7 +9,7 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.JBEmptyBorder
 import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.UIUtil
-import com.vaadin.plugin.copilot.CopilotPluginUtil
+import com.vaadin.plugin.copilot.service.CopilotDotfileService
 import com.vaadin.plugin.utils.doNotifyAboutVaadinProject
 import com.vaadin.plugin.utils.hasEndpoints
 import java.awt.Component
@@ -38,7 +38,7 @@ class VaadinStatusBarInfoPopupPanel(private val project: Project) : JPanel() {
     var afterRestart: (() -> Unit)? = null
 
     private fun copilotStatusRow(): JPanel {
-        val status = CopilotPluginUtil.isActive(project)
+        val status = project.getService(CopilotDotfileService::class.java).isActive()
         val wrapper = JPanel(VerticalLayout())
 
         val panel = JPanel(HorizontalLayout(UIUtil.DEFAULT_HGAP))

--- a/plugin/src/main/kotlin/com/vaadin/plugin/ui/VaadinStatusBarWidget.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/ui/VaadinStatusBarWidget.kt
@@ -11,7 +11,7 @@ import com.intellij.ui.awt.RelativePoint
 import com.intellij.util.Consumer
 import com.intellij.util.ui.JBUI.CurrentTheme.IconBadge
 import com.intellij.util.ui.UIUtil
-import com.vaadin.plugin.copilot.CopilotPluginUtil
+import com.vaadin.plugin.copilot.service.CopilotDotfileService
 import com.vaadin.plugin.utils.VaadinIcons
 import com.vaadin.plugin.utils.hasEndpoints
 import com.vaadin.plugin.utils.trackManualCopilotRestart
@@ -79,7 +79,7 @@ class VaadinStatusBarWidget(private val project: Project) : StatusBarWidget, Sta
     }
 
     override fun getTooltipText(): String {
-        if (CopilotPluginUtil.isActive(project) && hasEndpoints()) {
+        if (isActive() && hasEndpoints()) {
             return "Vaadin plugin is active, all features are available"
         }
 
@@ -95,7 +95,7 @@ class VaadinStatusBarWidget(private val project: Project) : StatusBarWidget, Sta
             return VaadinIcons.VAADIN
         }
 
-        if (CopilotPluginUtil.isActive(project) && hasEndpoints()) {
+        if (isActive() && hasEndpoints()) {
             return VaadinIcons.VAADIN
         }
 
@@ -104,5 +104,9 @@ class VaadinStatusBarWidget(private val project: Project) : StatusBarWidget, Sta
         }
 
         return IconManager.getInstance().withIconBadge(VaadinIcons.VAADIN, IconBadge.WARNING)
+    }
+
+    private fun isActive(): Boolean {
+        return project.getService(CopilotDotfileService::class.java).isActive()
     }
 }

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -62,6 +62,9 @@
                 displayName="Vaadin"/>
 
         <!-- Vaadin Copilot -->
+        <projectService id="CopilotDotfileService"
+            serviceImplementation="com.vaadin.plugin.copilot.service.CopilotDotfileServiceImpl"
+            serviceInterface="com.vaadin.plugin.copilot.service.CopilotDotfileService" />
         <notificationGroup id="Vaadin Copilot" displayType="BALLOON"/>
         <errorHandler implementation="com.vaadin.plugin.copilot.CopilotErrorHandler"/>
         <statusBarWidgetFactory implementation="com.vaadin.plugin.ui.VaadinStatusBarWidgetFactory"


### PR DESCRIPTION
Move dotfile management from static utility to service. Do not call filesystem methods to check if copilot service is active.