### PR TITLE
fix: Detect Vaadin on new projects

### DIFF
--- a/plugin/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
@@ -1,32 +1,51 @@
 package com.vaadin.plugin
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.roots.ModuleRootEvent
 import com.intellij.openapi.roots.ModuleRootListener
 import com.intellij.openapi.startup.ProjectActivity
 import com.vaadin.plugin.utils.doNotifyAboutVaadinProject
 import com.vaadin.plugin.utils.hasVaadin
 
-class VaadinProjectDetector : ModuleRootListener, ProjectActivity {
+class VaadinProjectDetector : ModuleRootListener, ProjectActivity, DumbService.DumbModeListener {
 
     private val LOG: Logger = Logger.getInstance(VaadinProjectDetector::class.java)
 
     override fun rootsChanged(event: ModuleRootEvent) {
-        ReadAction.run<Throwable> {
-            if (event.project.isOpen && hasVaadin(event.project)) {
-                doNotifyAboutVaadinProject(event.project)
-                LOG.info("Vaadin detected in dependencies of " + event.project.name)
+        ApplicationManager.getApplication().executeOnPooledThread {
+            ReadAction.run<Throwable> {
+                if (event.project.isOpen && hasVaadin(event.project)) {
+                    doNotifyAboutVaadinProject(event.project)
+                    LOG.info("Vaadin detected in dependencies of " + event.project.name)
+                }
             }
         }
     }
 
     override suspend fun execute(project: Project) {
-        ReadAction.run<Throwable> {
-            if (hasVaadin(project)) {
-                doNotifyAboutVaadinProject(project)
-                LOG.info("Vaadin detected during startup of " + project.name)
+        ApplicationManager.getApplication().executeOnPooledThread {
+            ReadAction.run<Throwable> {
+                if (hasVaadin(project)) {
+                    doNotifyAboutVaadinProject(project)
+                    LOG.info("Vaadin detected during startup of " + project.name)
+                }
+            }
+        }
+    }
+
+    override fun exitDumbMode() {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            ReadAction.run<Throwable> {
+                val project = ProjectManager.getInstance().openProjects.first()
+                if (hasVaadin(project)) {
+                    doNotifyAboutVaadinProject(project)
+                    LOG.info("Vaadin detected after dumb mode exited " + project.name)
+                }
             }
         }
     }

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotVaadinProjectListener.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/listeners/CopilotVaadinProjectListener.kt
@@ -1,15 +1,17 @@
 package com.vaadin.plugin.copilot.listeners
 
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.vaadin.plugin.copilot.CopilotPluginUtil.Companion.saveDotFile
+import com.vaadin.plugin.copilot.service.CopilotDotfileService
 import com.vaadin.plugin.listeners.VaadinProjectListener
 import com.vaadin.plugin.ui.VaadinStatusBarWidget
 
 class CopilotVaadinProjectListener : VaadinProjectListener {
 
     override fun vaadinProjectDetected(project: Project) {
-        if (!project.isDisposed) {
+        if (!project.isDisposed && !project.service<CopilotDotfileService>().isActive()) {
             saveDotFile(project)
             DumbService.getInstance(project).smartInvokeLater { VaadinStatusBarWidget.update(project) }
         }

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -124,6 +124,9 @@
                 class="com.vaadin.plugin.VaadinProjectDetector"
                 topic="com.intellij.openapi.roots.ModuleRootListener"/>
         <listener
+                class="com.vaadin.plugin.VaadinProjectDetector"
+                topic="com.intellij.openapi.project.DumbService$DumbModeListener"/>
+        <listener
                 class="com.vaadin.plugin.copilot.listeners.CopilotVaadinProjectListener"
                 topic="com.vaadin.plugin.listeners.VaadinProjectListener"/>
         <listener


### PR DESCRIPTION
Until now, Vaadin has been detected:
- on project opened
- on modules updated (dependencies)

Issue was that for new projects none of above worked due to indexing not finished.

This PR adds indexing finished (dumb mode) listener. For performance reasons existing methods have been moved to background thread.

Fixes: #354 
Fixes: #191

To test create new Vaadin project and wait until indexing is finished.