### PR TITLE
fix: Do not fall into infinite loop after initializing plugin

### DIFF
--- a/plugin/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/VaadinProjectDetector.kt
@@ -2,6 +2,7 @@ package com.vaadin.plugin
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
@@ -9,6 +10,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.roots.ModuleRootEvent
 import com.intellij.openapi.roots.ModuleRootListener
 import com.intellij.openapi.startup.ProjectActivity
+import com.vaadin.plugin.copilot.service.CopilotDotfileService
 import com.vaadin.plugin.utils.doNotifyAboutVaadinProject
 import com.vaadin.plugin.utils.hasVaadin
 
@@ -17,36 +19,29 @@ class VaadinProjectDetector : ModuleRootListener, ProjectActivity, DumbService.D
     private val LOG: Logger = Logger.getInstance(VaadinProjectDetector::class.java)
 
     override fun rootsChanged(event: ModuleRootEvent) {
-        ApplicationManager.getApplication().executeOnPooledThread {
-            ReadAction.run<Throwable> {
-                if (event.project.isOpen && hasVaadin(event.project)) {
-                    doNotifyAboutVaadinProject(event.project)
-                    LOG.info("Vaadin detected in dependencies of " + event.project.name)
-                }
-            }
+        if (event.project.isOpen) {
+            detectAndNotifyAboutVaadinProject { event.project }
         }
     }
 
     override suspend fun execute(project: Project) {
+        detectAndNotifyAboutVaadinProject { project }
+    }
+
+    override fun exitDumbMode() {
+        detectAndNotifyAboutVaadinProject { ProjectManager.getInstance().openProjects.first() }
+    }
+
+    private fun detectAndNotifyAboutVaadinProject(projectProvider: () -> Project) {
         ApplicationManager.getApplication().executeOnPooledThread {
             ReadAction.run<Throwable> {
-                if (hasVaadin(project)) {
+                val project = projectProvider.invoke()
+                if (!project.service<CopilotDotfileService>().isActive() && hasVaadin(project)) {
                     doNotifyAboutVaadinProject(project)
-                    LOG.info("Vaadin detected during startup of " + project.name)
+                    LOG.info("Vaadin project detected " + project.name)
                 }
             }
         }
     }
 
-    override fun exitDumbMode() {
-        ApplicationManager.getApplication().executeOnPooledThread {
-            ReadAction.run<Throwable> {
-                val project = ProjectManager.getInstance().openProjects.first()
-                if (hasVaadin(project)) {
-                    doNotifyAboutVaadinProject(project)
-                    LOG.info("Vaadin detected after dumb mode exited " + project.name)
-                }
-            }
-        }
-    }
 }


### PR DESCRIPTION
Updated Vaadin project detection on dumb mode exit not to cause infinite loop