### PR TITLE
chore: bring back javadocs removed by mistake

### DIFF
--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/service/CompilationStatusManagerService.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/service/CompilationStatusManagerService.kt
@@ -39,10 +39,20 @@ class CompilationStatusManagerService(private val project: Project) : Compilatio
         super.compilationFinished(aborted, errors, warnings, compileContext)
     }
 
+    /**
+     * Checks if the given [project] currently has compilation errors.
+     *
+     * @return `true` if the project has errors, otherwise `false`.
+     */
     fun hasCompilationError(): Boolean {
         return compilationErrorInfo?.hasCompilationError ?: false
     }
 
+    /**
+     * Retrieves the set of file names that caused compilation errors for the given [project].
+     *
+     * @return A [Set] of file paths that had errors, or an empty set if none are recorded.
+     */
     fun getErrorFiles(): Set<String> {
         return compilationErrorInfo?.errorFiles ?: emptySet()
     }


### PR DESCRIPTION
I removed by mistake javadocs which might be useful, bringing them back