### PR TITLE
chore: bump until to 252.*

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -55,7 +55,7 @@ jobs:
     needs: codeChecks
     strategy:
       matrix:
-        version: [ "2023.3", "251.14649.49" ] #EAP - use specific version
+        version: [ "2023.3", "252.13776.59" ] # for EAPs - use specific version
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -107,7 +107,7 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
 tasks {
   patchPluginXml {
     sinceBuild.set("233")
-    untilBuild.set("251.*")
+    untilBuild.set("252.*")
   }
 
   signPlugin {


### PR DESCRIPTION
Bump supported until to cover latest eap