### PR TITLE
chore: update min supported version to 2024.1

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -55,7 +55,7 @@ jobs:
     needs: codeChecks
     strategy:
       matrix:
-        version: [ "2023.3", "252.13776.59" ] # for EAPs - use specific version
+        version: [ "2024.1", "252.13776.59" ] # for EAPs - use specific version
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 // version for building plugin
-val buildVersion = "2023.3"
+val buildVersion = "2024.1"
 
 // version for verifying plugin, check validation.yml
 val verifyVersion =
@@ -106,7 +106,7 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
 
 tasks {
   patchPluginXml {
-    sinceBuild.set("233")
+    sinceBuild.set("241")
     untilBuild.set("252.*")
   }
 

--- a/plugin/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/actions/VaadinCompileOnSaveAction.kt
@@ -29,7 +29,7 @@ class VaadinCompileOnSaveAction : ActionsOnSaveFileDocumentManagerListener.Actio
         return VaadinCompileOnSaveActionInfo.isEnabledForProject(project)
     }
 
-    override fun processDocuments(project: Project, documents: Array<Document?>) {
+    override fun processDocuments(project: Project, documents: Array<Document>) {
         val task =
             object : Task.Backgroundable(project, "Vaadin: compiling...") {
                 override fun run(indicator: ProgressIndicator) {
@@ -40,7 +40,6 @@ class VaadinCompileOnSaveAction : ActionsOnSaveFileDocumentManagerListener.Actio
                     val vfsFiles =
                         ReadAction.compute<List<VirtualFile>, Exception> {
                             documents
-                                .filterNotNull()
                                 .mapNotNull { FileDocumentManager.getInstance().getFile(it) }
                                 .filter { fileIndex.isInSourceContent(it) }
                         }

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/handler/CompileFilesHandler.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/handler/CompileFilesHandler.kt
@@ -17,7 +17,7 @@ class CompileFilesHandler(project: Project, data: Map<String, Any>) : AbstractHa
                 .map { File(it) }
                 .filter { isFileInsideProject(project, it) }
                 .mapNotNull { VfsUtil.findFileByIoFile(it, true) }
-                .map { it.findDocument() }
+                .mapNotNull { it.findDocument() }
                 .toTypedArray()
 
         if (documents.isNotEmpty()) {


### PR DESCRIPTION
As in title, Vaadin should support IDE up to 1 year back.