### PR TITLE
fix: Extract properly in case of single directory

### DIFF
--- a/plugin/src/main/kotlin/com/vaadin/plugin/utils/DownloadUtil.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/utils/DownloadUtil.kt
@@ -21,6 +21,7 @@ import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import kotlin.io.path.extension
 import kotlin.io.path.isDirectory
+import kotlin.io.path.isHidden
 import kotlin.io.path.name
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
@@ -136,7 +137,7 @@ object DownloadUtil {
         // move contents from single zip directory
         if (moveSingleDir) {
             Files.list(outputPath)
-                .filter { paths -> paths.isDirectory() }
+                .filter { paths -> !paths.isHidden() && paths.isDirectory() }
                 .getIfSingle()
                 ?.let {
                     LOG.info("Archive contains single directory $it, moving to $outputPath")


### PR DESCRIPTION
Fixes:

```
Vaadin 1.0.0.eap191 invokes APIs marked with @ApiStatus.OverrideOnly, which indicates that the APIs must not be called outside the IntelliJ Platform but only overridden by its clients.

Override-only method usage violation (1)
AnAction.actionPerformed(AnActionEvent) (1)
Override-only method AnAction.actionPerformed(AnActionEvent) is invoked in VaadinStatusBarInfoPopupPanel.createJbrDownloadButton$lambda$2(...). This method is marked with @ApiStatus.OverrideOnly annotation, which indicates that the method must be only overridden but not invoked by client code. See documentation of the @ApiStatus.OverrideOnly for more info.
```