### PR TITLE
fix: Override-only API violation

### DIFF
--- a/plugin/src/main/kotlin/com/vaadin/plugin/actions/InstallJetbrainsRuntimeAction.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/actions/InstallJetbrainsRuntimeAction.kt
@@ -1,75 +1,14 @@
 package com.vaadin.plugin.actions
 
-import com.intellij.ide.actions.RevealFileAction
-import com.intellij.notification.Notification
-import com.intellij.notification.NotificationType
-import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.project.Project
-import com.vaadin.plugin.copilot.CopilotPluginUtil.Companion.NOTIFICATION_GROUP
 import com.vaadin.plugin.utils.JetbrainsRuntimeUtil
-import com.vaadin.plugin.utils.VaadinIcons
-import java.nio.file.Path
-import kotlin.io.path.nameWithoutExtension
 
 class InstallJetbrainsRuntimeAction : AnAction() {
 
-    internal class RevealJBRFileAction(val path: Path) : RevealFileAction() {
-        override fun actionPerformed(e: AnActionEvent) {
-            openFile(path)
-        }
-    }
-
     override fun actionPerformed(event: AnActionEvent) {
-
         if (event.project != null && event.project?.isDisposed == false) {
-            JetbrainsRuntimeUtil.downloadLatestJBR(event.project!!).thenApply { afterDownload(it, event.project!!) }
+            JetbrainsRuntimeUtil.downloadAndSetupLatestJBR(event.project!!)
         }
-    }
-
-    private fun afterDownload(result: JetbrainsRuntimeUtil.JBRInstallResult, project: Project) {
-        if (result.status == JetbrainsRuntimeUtil.JBRInstallStatus.INSTALLED) {
-            val version = result.path!!.nameWithoutExtension
-            Notifications.Bus.notify(
-                Notification(
-                        NOTIFICATION_GROUP,
-                        "JetBrains Runtime $version installed successfully",
-                        NotificationType.INFORMATION)
-                    .setIcon(VaadinIcons.VAADIN)
-                    .addAction(RevealJBRFileAction(result.path)),
-                project,
-            )
-            setupProjectSdk(project, result.path)
-            return
-        }
-
-        if (result.status == JetbrainsRuntimeUtil.JBRInstallStatus.ALREADY_EXISTS) {
-            val version = result.path!!.nameWithoutExtension
-            Notifications.Bus.notify(
-                Notification(
-                        NOTIFICATION_GROUP,
-                        "Latest JetBrains Runtime $version is already installed",
-                        NotificationType.INFORMATION)
-                    .setIcon(VaadinIcons.VAADIN)
-                    .addAction(RevealJBRFileAction(result.path)),
-                project,
-            )
-            setupProjectSdk(project, result.path)
-            return
-        }
-
-        Notifications.Bus.notify(
-            Notification(
-                    NOTIFICATION_GROUP,
-                    "JetBrains Runtime installation failed, see logs for details",
-                    NotificationType.WARNING)
-                .setIcon(VaadinIcons.VAADIN),
-            project,
-        )
-    }
-
-    private fun setupProjectSdk(project: Project, sdkHomePath: Path) {
-        JetbrainsRuntimeUtil.addAndSetProjectSdk(project, sdkHomePath.toString())
     }
 }

--- a/plugin/src/main/kotlin/com/vaadin/plugin/ui/VaadinStatusBarInfoPopupPanel.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/ui/VaadinStatusBarInfoPopupPanel.kt
@@ -1,10 +1,6 @@
 package com.vaadin.plugin.ui
 
 import com.intellij.icons.AllIcons
-import com.intellij.ide.DataManager
-import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.actionSystem.ActionPlaces
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
@@ -15,6 +11,7 @@ import com.intellij.util.ui.JBFont
 import com.intellij.util.ui.UIUtil
 import com.vaadin.plugin.copilot.service.CopilotDotfileService
 import com.vaadin.plugin.hotswapagent.JdkUtil
+import com.vaadin.plugin.utils.JetbrainsRuntimeUtil
 import com.vaadin.plugin.utils.doNotifyAboutVaadinProject
 import com.vaadin.plugin.utils.hasEndpoints
 import com.vaadin.plugin.utils.trackManualCopilotRestart
@@ -106,12 +103,7 @@ class VaadinStatusBarInfoPopupPanel(private val project: Project) : JPanel() {
     private fun createJbrDownloadButton(): JButton {
         val downloadButton = JButton(AllIcons.Actions.Download)
         downloadButton.addActionListener {
-            val action = ActionManager.getInstance().getAction("vaadin.jbr.install")
-            val event =
-                AnActionEvent.createFromAnAction(
-                    action, null, ActionPlaces.UNKNOWN, DataManager.getInstance().getDataContext(this))
-            action.actionPerformed(event)
-            refreshPopup?.invoke()
+            JetbrainsRuntimeUtil.downloadAndSetupLatestJBR(project).thenRun { refreshPopup?.invoke() }
         }
         return downloadButton
     }


### PR DESCRIPTION
Fixes:

```
Vaadin 1.0.0.eap191 invokes APIs marked with @ApiStatus.OverrideOnly, which indicates that the APIs must not be called outside the IntelliJ Platform but only overridden by its clients.

Override-only method usage violation (1)
AnAction.actionPerformed(AnActionEvent) (1)
Override-only method AnAction.actionPerformed(AnActionEvent) is invoked in VaadinStatusBarInfoPopupPanel.createJbrDownloadButton$lambda$2(...). This method is marked with @ApiStatus.OverrideOnly annotation, which indicates that the method must be only overridden but not invoked by client code. See documentation of the @ApiStatus.OverrideOnly for more info.
```