### PR TITLE
Modules detection based in External Modules API

### DIFF
--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
@@ -4,6 +4,7 @@ import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.progress.ProgressIndicator
@@ -38,6 +39,8 @@ import io.netty.handler.codec.http.HttpResponseStatus
 import java.io.BufferedWriter
 import java.io.IOException
 import java.io.StringWriter
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.Properties
 import org.jetbrains.jps.model.java.JavaResourceRootType
 import org.jetbrains.jps.model.java.JavaSourceRootType
@@ -170,56 +173,46 @@ class CopilotPluginUtil {
          * roots, source paths, test source paths, resource paths, test resource paths, and output path.
          */
         fun getModulesInfo(project: Project): List<ModuleInfo> {
-            val modules = HashMap<String, ModuleInfo>()
+
+            val modulesInfo = HashMap<String, ModuleInfo>()
             val moduleManager = ModuleManager.getInstance(project)
             val projectModules = moduleManager.modules
-            val moduleMap = projectModules.associateBy({ it.name }, { it })
-            projectModules.forEach { module: Module ->
+
+            val modulePathMap = buildExternalModulePathMap(projectModules)
+
+            projectModules.forEach { module ->
+                val parent = findExternalParentModule(module, modulePathMap)
+                val targetModule = parent ?: module
+                val targetName = targetModule.name
+
                 val moduleRootManager = ModuleRootManager.getInstance(module)
 
-                val dotIndex = module.name.lastIndexOf('.')
-                var targetModuleName = module.name
-                var targetModule = module
-                if (dotIndex > 0) {
-                    val base = module.name.substring(0, dotIndex)
-                    if (moduleMap.containsKey(base)) {
-                        // Add the modules from this module to the main one
-                        targetModuleName = base
-                        targetModule = moduleMap[base]!!
-                    }
-                }
-
                 val targetModuleInfo =
-                    modules.computeIfAbsent(
-                        targetModuleName,
-                        {
-                            val targetModuleRootManager = ModuleRootManager.getInstance(targetModule)
-                            val contentRoots = targetModuleRootManager.contentRoots.map { it.path }
+                    modulesInfo.computeIfAbsent(targetName) {
+                        val targetRootManager = ModuleRootManager.getInstance(targetModule)
+                        val contentRoots = targetRootManager.contentRoots.map { it.path }
 
-                            val compilerModuleExtension = CompilerModuleExtension.getInstance(module)
-                            val outputPath = compilerModuleExtension?.compilerOutputPath
+                        val compilerModuleExtension = CompilerModuleExtension.getInstance(targetModule)
+                        val outputPath = compilerModuleExtension?.compilerOutputPath?.path
 
-                            ModuleInfo(
-                                targetModuleName,
-                                contentRoots,
-                                ArrayList<String>(),
-                                ArrayList<String>(),
-                                ArrayList<String>(),
-                                ArrayList<String>(),
-                                outputPath?.path)
-                        })
+                        ModuleInfo(
+                            targetName, contentRoots, ArrayList(), ArrayList(), ArrayList(), ArrayList(), outputPath)
+                    }
 
-                // Note that the JavaSourceRootType.SOURCE also includes Kotlin source folders
                 targetModuleInfo.javaSourcePaths.addAll(
                     moduleRootManager.getSourceRoots(JavaSourceRootType.SOURCE).map { it.path })
+
                 targetModuleInfo.javaTestSourcePaths.addAll(
                     moduleRootManager.getSourceRoots(JavaSourceRootType.TEST_SOURCE).map { it.path })
+
                 targetModuleInfo.resourcePaths.addAll(
                     moduleRootManager.getSourceRoots(JavaResourceRootType.RESOURCE).map { it.path })
+
                 targetModuleInfo.testResourcePaths.addAll(
                     moduleRootManager.getSourceRoots(JavaResourceRootType.TEST_RESOURCE).map { it.path })
             }
-            return modules.values.toList()
+
+            return modulesInfo.values.toList()
         }
 
         /**
@@ -235,6 +228,35 @@ class CopilotPluginUtil {
             }
             moduleBaseDirectories["base-module"] = listOf(project.basePath) as List<String>
             return moduleBaseDirectories
+        }
+
+        private fun buildExternalModulePathMap(modules: Array<Module>): Map<Path, Module> {
+            val map = HashMap<Path, Module>()
+
+            modules.forEach { module ->
+                val path = ExternalSystemApiUtil.getExternalProjectPath(module)
+                if (path != null) {
+                    map[Paths.get(path).normalize()] = module
+                }
+            }
+
+            return map
+        }
+
+        private fun findExternalParentModule(module: Module, modulePathMap: Map<Path, Module>): Module? {
+
+            val modulePathString = ExternalSystemApiUtil.getExternalProjectPath(module) ?: return null
+            var path: Path? = Paths.get(modulePathString).normalize().parent
+
+            while (path != null) {
+                val parentModule = modulePathMap[path]
+                if (parentModule != null) {
+                    return parentModule
+                }
+                path = path.parent
+            }
+
+            return null
         }
     }
 }

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
@@ -174,41 +174,69 @@ class CopilotPluginUtil {
          */
         fun getModulesInfo(project: Project): List<ModuleInfo> {
 
-            val modulesInfo = HashMap<String, ModuleInfo>()
-            val moduleManager = ModuleManager.getInstance(project)
-            val projectModules = moduleManager.modules
+            val modules = ModuleManager.getInstance(project).modules
 
-            val modulePathMap = buildExternalModulePathMap(projectModules)
+            // Cache expensive lookups
+            val rootManagers = HashMap<Module, ModuleRootManager>(modules.size)
+            val compilerExtensions = HashMap<Module, CompilerModuleExtension?>(modules.size)
+            val externalPaths = HashMap<Module, Path>(modules.size)
+            val modulePathMap = HashMap<Path, Module>(modules.size)
 
-            projectModules.forEach { module ->
-                val parent = findExternalParentModule(module, modulePathMap)
+            modules.forEach { module ->
+                rootManagers[module] = ModuleRootManager.getInstance(module)
+                compilerExtensions[module] = CompilerModuleExtension.getInstance(module)
+
+                val externalPath = ExternalSystemApiUtil.getExternalProjectPath(module)
+                if (externalPath != null) {
+                    val normalized = Paths.get(externalPath).normalize()
+                    externalPaths[module] = normalized
+                    modulePathMap[normalized] = module
+                }
+            }
+
+            fun findParent(module: Module): Module? {
+                var path = externalPaths[module]?.parent ?: return null
+
+                while (path != null) {
+                    modulePathMap[path]?.let {
+                        return it
+                    }
+                    path = path.parent
+                }
+                return null
+            }
+
+            val modulesInfo = LinkedHashMap<String, ModuleInfo>()
+
+            modules.forEach { module ->
+                val parent = findParent(module)
                 val targetModule = parent ?: module
                 val targetName = targetModule.name
 
-                val moduleRootManager = ModuleRootManager.getInstance(module)
+                val moduleRootManager = rootManagers[module]!!
 
-                val targetModuleInfo =
+                val targetInfo =
                     modulesInfo.computeIfAbsent(targetName) {
-                        val targetRootManager = ModuleRootManager.getInstance(targetModule)
+                        val targetRootManager = rootManagers[targetModule]!!
+
                         val contentRoots = targetRootManager.contentRoots.map { it.path }
 
-                        val compilerModuleExtension = CompilerModuleExtension.getInstance(targetModule)
-                        val outputPath = compilerModuleExtension?.compilerOutputPath?.path
+                        val outputPath = compilerExtensions[targetModule]?.compilerOutputPath?.path
 
-                        ModuleInfo(
+                        CopilotPluginUtil.ModuleInfo(
                             targetName, contentRoots, ArrayList(), ArrayList(), ArrayList(), ArrayList(), outputPath)
                     }
 
-                targetModuleInfo.javaSourcePaths.addAll(
+                targetInfo.javaSourcePaths.addAll(
                     moduleRootManager.getSourceRoots(JavaSourceRootType.SOURCE).map { it.path })
 
-                targetModuleInfo.javaTestSourcePaths.addAll(
+                targetInfo.javaTestSourcePaths.addAll(
                     moduleRootManager.getSourceRoots(JavaSourceRootType.TEST_SOURCE).map { it.path })
 
-                targetModuleInfo.resourcePaths.addAll(
+                targetInfo.resourcePaths.addAll(
                     moduleRootManager.getSourceRoots(JavaResourceRootType.RESOURCE).map { it.path })
 
-                targetModuleInfo.testResourcePaths.addAll(
+                targetInfo.testResourcePaths.addAll(
                     moduleRootManager.getSourceRoots(JavaResourceRootType.TEST_RESOURCE).map { it.path })
             }
 
@@ -228,35 +256,6 @@ class CopilotPluginUtil {
             }
             moduleBaseDirectories["base-module"] = listOf(project.basePath) as List<String>
             return moduleBaseDirectories
-        }
-
-        private fun buildExternalModulePathMap(modules: Array<Module>): Map<Path, Module> {
-            val map = HashMap<Path, Module>()
-
-            modules.forEach { module ->
-                val path = ExternalSystemApiUtil.getExternalProjectPath(module)
-                if (path != null) {
-                    map[Paths.get(path).normalize()] = module
-                }
-            }
-
-            return map
-        }
-
-        private fun findExternalParentModule(module: Module, modulePathMap: Map<Path, Module>): Module? {
-
-            val modulePathString = ExternalSystemApiUtil.getExternalProjectPath(module) ?: return null
-            var path: Path? = Paths.get(modulePathString).normalize().parent
-
-            while (path != null) {
-                val parentModule = modulePathMap[path]
-                if (parentModule != null) {
-                    return parentModule
-                }
-                path = path.parent
-            }
-
-            return null
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes [Multi module issue](https://github.com/vaadin/copilot/issues/119#issuecomment-4011837983)

We had a submodule detection based on the module alias given by intelliJ winch is not reliable enough because it can be edited by the user and the '.' logic is not safe since users can also use them for folder names. 

This PR uses the ExternalSystemApi of IntelliJ that is meant for maven/gradle modules 

The key idea:

- Get the external project path for every module.

- A module's parent module is the module whose external project path is the closest ancestor directory of the child module path.

- Group modules under that parent.

Key optimizations:

⚡ Single pass parent resolution (O(n))
⚡ Cache ModuleRootManager (expensive service lookup)
⚡ Cache CompilerModuleExtension
⚡ Avoid repeated ExternalSystemApiUtil calls
⚡ Avoid repeated path parsing
⚡ Use LinkedHashMap to preserve module order

## Type of change

- [x] Bugfix
- [ ] Feature
