### PR TITLE
fix: Gradle contents root detection updated

### DIFF
--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
@@ -195,9 +195,10 @@ class CopilotPluginUtil {
             }
 
             // Among modules sharing a path, prefer the one with the fewest dots in its name.
-            // Gradle convention: root module has no dots, source-set modules add ".main"/".test".
-            // Excludes self and any submodule of self (its dotted-descendants), which can never be
-            // parents.
+            // Gradle convention: a Gradle project's source-set modules (".main"/".test") share the
+            // externalPath of the owning project module, so we roll them up to the shortest-named
+            // sibling at that same path. We do NOT walk to ancestor paths — Gradle subprojects are
+            // independent modules, not children of the root project.
             fun pickCandidate(candidates: List<Module>, self: Module): Module? {
                 val selfPrefix = self.name + "."
                 return candidates
@@ -207,17 +208,9 @@ class CopilotPluginUtil {
             }
 
             fun findParent(module: Module): Module? {
-                var path = externalPaths[module] ?: return null
-
-                while (path != null) {
-                    modulePathMap[path]?.let { candidates ->
-                        pickCandidate(candidates, module)?.let {
-                            return it
-                        }
-                    }
-                    path = path.parent
-                }
-                return null
+                val path = externalPaths[module] ?: return null
+                val candidates = modulePathMap[path] ?: return null
+                return pickCandidate(candidates, module)
             }
 
             val modulesInfo = LinkedHashMap<String, ModuleInfo>()

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
@@ -50,7 +50,7 @@ class CopilotPluginUtil {
     @JvmRecord
     data class ModuleInfo(
         val name: String,
-        val contentRoots: List<String>,
+        val contentRoots: ArrayList<String>,
         val javaSourcePaths: ArrayList<String>,
         val javaTestSourcePaths: ArrayList<String>,
         val resourcePaths: ArrayList<String>,
@@ -180,7 +180,7 @@ class CopilotPluginUtil {
             val rootManagers = HashMap<Module, ModuleRootManager>(modules.size)
             val compilerExtensions = HashMap<Module, CompilerModuleExtension?>(modules.size)
             val externalPaths = HashMap<Module, Path>(modules.size)
-            val modulePathMap = HashMap<Path, Module>(modules.size)
+            val modulePathMap = HashMap<Path, MutableList<Module>>(modules.size)
 
             modules.forEach { module ->
                 rootManagers[module] = ModuleRootManager.getInstance(module)
@@ -190,16 +190,30 @@ class CopilotPluginUtil {
                 if (externalPath != null) {
                     val normalized = Paths.get(externalPath).normalize()
                     externalPaths[module] = normalized
-                    modulePathMap[normalized] = module
+                    modulePathMap.getOrPut(normalized) { mutableListOf() }.add(module)
                 }
             }
 
+            // Among modules sharing a path, prefer the one with the fewest dots in its name.
+            // Gradle convention: root module has no dots, source-set modules add ".main"/".test".
+            // Excludes self and any submodule of self (its dotted-descendants), which can never be
+            // parents.
+            fun pickCandidate(candidates: List<Module>, self: Module): Module? {
+                val selfPrefix = self.name + "."
+                return candidates
+                    .asSequence()
+                    .filter { it != self && !it.name.startsWith(selfPrefix) }
+                    .minWithOrNull(compareBy({ it.name.count { c -> c == '.' } }, { it.name.length }, { it.name }))
+            }
+
             fun findParent(module: Module): Module? {
-                var path = externalPaths[module]?.parent ?: return null
+                var path = externalPaths[module] ?: return null
 
                 while (path != null) {
-                    modulePathMap[path]?.let {
-                        return it
+                    modulePathMap[path]?.let { candidates ->
+                        pickCandidate(candidates, module)?.let {
+                            return it
+                        }
                     }
                     path = path.parent
                 }
@@ -217,15 +231,17 @@ class CopilotPluginUtil {
 
                 val targetInfo =
                     modulesInfo.computeIfAbsent(targetName) {
-                        val targetRootManager = rootManagers[targetModule]!!
-
-                        val contentRoots = targetRootManager.contentRoots.map { it.path }
-
                         val outputPath = compilerExtensions[targetModule]?.compilerOutputPath?.path
 
                         CopilotPluginUtil.ModuleInfo(
-                            targetName, contentRoots, ArrayList(), ArrayList(), ArrayList(), ArrayList(), outputPath)
+                            targetName, ArrayList(), ArrayList(), ArrayList(), ArrayList(), ArrayList(), outputPath)
                     }
+
+                moduleRootManager.contentRoots.forEach { root ->
+                    if (root.path !in targetInfo.contentRoots) {
+                        targetInfo.contentRoots.add(root.path)
+                    }
+                }
 
                 targetInfo.javaSourcePaths.addAll(
                     moduleRootManager.getSourceRoots(JavaSourceRootType.SOURCE).map { it.path })

--- a/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/copilot/CopilotPluginUtil.kt
@@ -55,7 +55,11 @@ class CopilotPluginUtil {
         val javaTestSourcePaths: ArrayList<String>,
         val resourcePaths: ArrayList<String>,
         val testResourcePaths: ArrayList<String>,
-        val outputPath: String?
+        val outputPath: String?,
+        // Authoritative base directory of the (sub)project. For Gradle/Maven this is the external
+        // project path; for plain IDEA modules it falls back to the first content root. Prefer this
+        // over contentRoots[0] — that field is only deterministic by convention.
+        val basePath: String?
     )
 
     @JvmRecord data class ProjectInfo(val basePath: String?, val modules: List<ModuleInfo>)
@@ -224,10 +228,24 @@ class CopilotPluginUtil {
 
                 val targetInfo =
                     modulesInfo.computeIfAbsent(targetName) {
+                        // Seed contentRoots from the target module so contentRoots[0] is the
+                        // (sub)project's own root regardless of which sibling is iterated first.
+                        // Keep this to back compatibility on older copilot versions
+                        // Newer consumers should use dedicated basePath field
+                        val targetRootManager = rootManagers[targetModule]!!
+                        val initialRoots = ArrayList(targetRootManager.contentRoots.map { it.path })
+                        val basePath = externalPaths[targetModule]?.toString() ?: initialRoots.firstOrNull()
                         val outputPath = compilerExtensions[targetModule]?.compilerOutputPath?.path
 
                         CopilotPluginUtil.ModuleInfo(
-                            targetName, ArrayList(), ArrayList(), ArrayList(), ArrayList(), ArrayList(), outputPath)
+                            targetName,
+                            initialRoots,
+                            ArrayList(),
+                            ArrayList(),
+                            ArrayList(),
+                            ArrayList(),
+                            outputPath,
+                            basePath)
                     }
 
                 moduleRootManager.contentRoots.forEach { root ->


### PR DESCRIPTION
Reworked getModulesInfo to correctly handle Gradle multi-module projects imported with "separate module per source set":

- Source-set rollup: modules like module.main / module.test share an externalPath with their owning module. They're now grouped under the owner using a fewest-dots heuristic at the same path, with their content roots, source roots, and resource roots merged into a single ModuleInfo.
- Subproject independence: Gradle subprojects stay as their own ModuleInfo entries instead of being absorbed into the root project. The parent-lookup deliberately does not walk to ancestor paths.
- Stable project root: contentRoots[0] is now deterministically the (sub)project's own root, regardless of ModuleManager iteration order — old consumers keep working.
- New basePath field on ModuleInfo: the authoritative base directory, sourced from ExternalSystemApiUtil.getExternalProjectPath (with a fallback to the first content root for non-external modules). Recommended for new consumers.

Net effect: one ModuleInfo per Gradle (sub)project, source-sets correctly merged in, no cross-module leakage, and a reliable base path exposed to clients.