### PR TITLE
feat: Show Hotswap debug button in main toolbar

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -87,6 +87,7 @@ intellijPlatform {
   pluginVerification {
     ides { create(IntelliJPlatformType.IntellijIdea, verifyVersion) }
     verificationReportsFormats = listOf(VerifyPluginTask.VerificationReportsFormats.MARKDOWN)
+    ignoredProblemsFile = file("verifier-ignored-problems.txt")
   }
 }
 

--- a/plugin/src/main/kotlin/com/vaadin/plugin/actions/DebugUsingHotSwapAgentToolbarAction.kt
+++ b/plugin/src/main/kotlin/com/vaadin/plugin/actions/DebugUsingHotSwapAgentToolbarAction.kt
@@ -1,0 +1,48 @@
+package com.vaadin.plugin.actions
+
+import com.intellij.execution.ExecutionManager
+import com.intellij.execution.ExecutorRegistry
+import com.intellij.execution.RunManager
+import com.intellij.execution.runners.ExecutionUtil
+import com.intellij.internal.statistic.collectors.fus.actions.persistence.ActionIdProvider
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
+import com.vaadin.plugin.hotswapagent.HotswapAgentExecutor
+import com.vaadin.plugin.utils.VaadinIcons
+
+class DebugUsingHotSwapAgentToolbarAction : AnAction(), DumbAware, ActionIdProvider {
+
+    override fun getId(): String = HotswapAgentExecutor.ID
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        val executor = ExecutorRegistry.getInstance().getExecutorById(HotswapAgentExecutor.ID)
+        if (project == null || executor == null || !executor.isApplicable(project)) {
+            e.presentation.isEnabledAndVisible = false
+            return
+        }
+        e.presentation.isEnabledAndVisible = true
+        val selected = RunManager.getInstance(project).selectedConfiguration
+        val running =
+            selected != null &&
+                ExecutionManager.getInstance(project).getRunningDescriptors { it === selected }.isNotEmpty()
+        if (running) {
+            e.presentation.text = "Rerun using HotSwapAgent"
+            e.presentation.icon = VaadinIcons.RERUN_HOTSWAP
+        } else {
+            e.presentation.text = "Debug using HotSwapAgent"
+            e.presentation.icon = VaadinIcons.DEBUG_HOTSWAP
+        }
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val executor = ExecutorRegistry.getInstance().getExecutorById(HotswapAgentExecutor.ID) ?: return
+        val settings = RunManager.getInstance(project).selectedConfiguration ?: return
+        ExecutionUtil.runConfiguration(settings, executor)
+    }
+}

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -115,6 +115,15 @@
                           relative-to-action="Rerun"
                           anchor="after" />
         </action>
+        <action
+                id="HotSwap.debug.toolbar"
+                class="com.vaadin.plugin.actions.DebugUsingHotSwapAgentToolbarAction"
+                text="Debug using HotSwapAgent"
+                icon="/vaadin/icons/debug.svg">
+            <add-to-group group-id="RunToolbarMainActionGroup"
+                          relative-to-action="MoreRunToolbarActions"
+                          anchor="before"/>
+        </action>
     </actions>
 
     <projectListeners>

--- a/plugin/verifier-ignored-problems.txt
+++ b/plugin/verifier-ignored-problems.txt
@@ -1,0 +1,7 @@
+// IntelliJ Plugin Verifier — ignored problems
+// Format: [<plugin_id>[:<plugin_version>]:]<message_regexp>   (regex cannot contain ':')
+
+// FUS package houses ActionIdProvider, the only API MoreRunToolbarActions uses to dedupe
+// our executor from the new-UI Run widget's "..." dropdown when the same action is inline.
+// The platform's own ExecutorAction implements this interface for the same reason.
+com.vaadin.intellij-plugin::.*ActionIdProvider reference


### PR DESCRIPTION
Adds the "Debug using HotSwapAgent" action to RunToolbarMainActionGroup so it renders inline next to Run/Debug/Stop instead of being hidden in the new-UI "..." dropdown. A new AnAction is used (rather than the existing dashboard-bound ExecutorAction) because the dashboard base class force-hides itself outside the Services view. Implements ActionIdProvider so MoreRunToolbarActions auto-removes the duplicate entry from the dropdown.
